### PR TITLE
(MAINT) Ignore `convert_report.txt`

### DIFF
--- a/moduleroot/.gitignore.erb
+++ b/moduleroot/.gitignore.erb
@@ -19,6 +19,7 @@
 /spec/fixtures/modules/
 /tmp/
 /vendor/
+/convert_report.txt
 
 <% (@configs['paths'] || []).each do |path| -%>
 <%= path %>


### PR DESCRIPTION
`convert_report.txt` is generated during `pdk convert` and should not be committed.