### PR TITLE
(MODULES-6333) Add Puppet 5 to matrix for travis and appveyor

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -12,6 +12,7 @@
   bundler_args: --without system_tests
   env:
     - PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
+    - PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
   docker_sets:
   docker_defaults:
     # values will replace @@SET@@ with the docker_sets' value
@@ -39,6 +40,9 @@ appveyor.yml:
     - RUBY_VERSION: 24-x64
       CHECK: spec
     - RUBY_VERSION: 21-x64
+      CHECK: spec
+    - PUPPET_GEM_VERSION: '~> 5.0'
+      RUBY_VER: 24-x64
       CHECK: spec
   test_script:
     - bundle exec rake %CHECK%


### PR DESCRIPTION
This PR is an attempt to bring the default configuration closer
to that of config_defaults in modulesync_configs.
  