### PR TITLE
Fix empty config issue with .travis.yml.erb

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -64,8 +64,8 @@ branches:
   only:
     - master
     - /^v\d/
-<% if ! @configs['branches']['only'].nil? -%>
-<%   @configs['branches']['only'].each do |branch| -%>
+<% if @configs['branches'] -%>
+<%   @configs['branches'].each do |branch| -%>
     - <%= branch %>
 <%   end -%>
 <% end -%>


### PR DESCRIPTION
The previous code for this broke when branches:only was empty, as a result we've decided to make the key simply as 'branches' to avoid any confusion when reading in the config.