### PR TITLE
Removing openssl issue from appveyor config as is no longer required

### DIFF
--- a/moduleroot/appveyor.yml.erb
+++ b/moduleroot/appveyor.yml.erb
@@ -23,17 +23,6 @@ matrix:
   fast_finish: true
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
-  # Due to a bug in the version of OpenSSL shipped with Ruby 2.4.1 on Windows
-  # (https://bugs.ruby-lang.org/issues/11033). Errors are ignored because the
-  # mingw gem calls out to pacman to install OpenSSL which is already
-  # installed, causing gem to raise a warning that powershell determines to be
-  # a fatal error.
-  - ps: |
-      $ErrorActionPreference = "SilentlyContinue"
-      if($env:RUBY_VERSION -eq "24-x64") {
-        gem install openssl "~> 2.0.4" --no-rdoc --no-ri -- --with-openssl-dir=C:\msys64\mingw64
-      }
-      $host.SetShouldExit(0)
   - <%= @configs['appveyor_bundle_install'] %>
   - type Gemfile.lock
 build: off


### PR DESCRIPTION
(https://bugs.ruby-lang.org/issues/11033)
This workaround is no longer required and should be removed.
The PDK is reverting the removal of this which was rolled out by modulesync as can be seen in this PR:
https://github.com/puppetlabs/puppetlabs-concat/commit/1587974bd7e1330a6ec329a54ccb97647f302c08