### PR TITLE
WIP: Fix #21, mismatched naming of documentation directory

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -17,7 +17,7 @@
       - '/.vagrant/'
       - '/coverage/'
       - '/bin/'
-      - '/doc/'
+      - '/docs/'
       - '/Gemfile.local'
       - '/Gemfile.lock'
       - '/junit/'


### PR DESCRIPTION
This PR fixes the mismatched naming of the documentation directory, originally set to /doc/ in .gitignore and docs/ in .yardopts as mentioned in #21. 

In this solution, the .gitignore settings have been modified to replace /doc/ with /docs/.

Alternatively, we could:

1. Add both to .gitignore, keeping docs/ in .yardopts
2. Replace docs/ with doc/ in .yardopts