### PR TITLE
(maint) Allows customization of .yardopts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |docker_defaults |Defines what values are used as default when using the `docker_sets` definition. Includes ruby version, sudo being enabled, the distro, the services, the env variables and the script to execute.|
 |includes        |Ensures that the .travis file includes the following checks by default: Rubocop, Puppet Lint, Metadata Lint.|
 
+### .yardopts
+
+>[YARD](https://yardoc.org/) is a documentation generation tool for the Ruby programming language. It enables the user to generate consistent, usable documentation that can be exported to a number of formats very easily, and also supports extending for custom Ruby constructs such as custom class level definitions.
+
+| Key            | Description   |
+| :------------- |:--------------|
+| markup         |Specifies the markup formatting of your documentation. Default is `markdown`.|
+| optional       |Define any additional arguments you want to pass through to the `yardoc` command.|
 
 ### appveyor.yml
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -53,6 +53,8 @@
     - env: CHECK=rubocop
     - env: CHECK="syntax lint"
     - env: CHECK=metadata_lint
+.yardopts:
+  markup: markdown
 appveyor.yml:
   appveyor_bundle_install: "bundle install --jobs 4 --retry 2 --without system_tests"
   environment:

--- a/moduleroot/.yardopts.erb
+++ b/moduleroot/.yardopts.erb
@@ -1,2 +1,8 @@
---markup markdown
---output-dir docs/
+<% if !@configs.nil? && @configs.has_key?('markup') -%>
+<%= "--markup #{@configs['markup']}" %>
+<% end -%>
+<% if !@configs.nil? && @configs.has_key?('optional') -%>
+<%   @configs['optional'].each do |arg| -%>
+<%= arg %>
+<%   end -%>
+<% end -%>


### PR DESCRIPTION
This PR is to replace #22 , instead of adding the docs/ directory to the ignore files, we should be defaulting to the default output-dir of yardoc, and allow customization of the options in a .sync.yml.

Fixes #21 
Closes #22 