### PR TITLE
Additional changes to travis and appveyor

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -35,11 +35,9 @@
 .travis.yml:
   ruby_versions:
     - 2.4.1
-    - 2.1.9
-  bundler_args: --without system_tests
   env:
-    - PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
     - PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
+  bundler_args: --without system_tests
   docker_sets:
   docker_defaults:
     # values will replace @@SET@@ with the docker_sets' value
@@ -53,12 +51,13 @@
     - env: CHECK=rubocop
     - env: CHECK="syntax lint"
     - env: CHECK=metadata_lint
+    - env: CHECK=spec
+    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
+      rvm:  2.1.9
 .yardopts:
   markup: markdown
 appveyor.yml:
   appveyor_bundle_install: "bundle install --jobs 4 --retry 2 --without system_tests"
-  environment:
-    PUPPET_GEM_VERSION: "~> 4.0"
   matrix:
     - RUBY_VERSION: 24-x64
       CHECK: "syntax lint"
@@ -66,11 +65,16 @@ appveyor.yml:
       CHECK: metadata_lint
     - RUBY_VERSION: 24-x64
       CHECK: rubocop
-    - RUBY_VERSION: 24-x64
+    - PUPPET_GEM_VERSION: ~> 4.0
+      RUBY_VERSION: 21
       CHECK: spec
-    - RUBY_VERSION: 21-x64
+    - PUPPET_GEM_VERSION: ~> 4.0
+      RUBY_VERSION: 21-x64
       CHECK: spec
-    - PUPPET_GEM_VERSION: '~> 5.0'
+    - PUPPET_GEM_VERSION: ~> 5.0
+      RUBY_VERSION: 24
+      CHECK: spec
+    - PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24-x64
       CHECK: spec
   test_script:


### PR DESCRIPTION
Removed the unnecessary Puppet 4 Ruby 2.4.1 run from .travis, and ensured appveyor is running tests on both 64 and 32 bit ruby with appropriate Puppet versions.