### PR TITLE
Fix geppetto metadata to work with newer versions of eclipse

### DIFF
--- a/moduleroot_init/.project.erb
+++ b/moduleroot_init/.project.erb
@@ -18,6 +18,6 @@
 	</buildSpec>
 	<natures>
 		<nature>com.puppetlabs.geppetto.pp.dsl.ui.puppetNature</nature>
-		<nature>com.eclipse.xtext.ui.shared.xtextNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
nature name is org.eclipse.. instead of com.eclipse...