### PR TITLE
Fix Gemfile template

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -24,7 +24,7 @@ def gem_spec(gem, max_len)
   options << "require: false" if gem['from_env'].nil?
   options << "git: '#{gem['git']}'" unless gem['git'].nil?
   options << "branch: '#{gem['branch']}'" unless gem['branch'].nil?
-  options << "ref: '#{gem['ref']}'" unless gem['branch'].nil?
+  options << "ref: '#{gem['ref']}'" unless gem['ref'].nil?
   options << "platforms: #{gem['platforms'].inspect}" unless gem['platforms'].nil?
 
   unless options.empty?


### PR DESCRIPTION
Adding an additional module to the Gemfile with something like:
```yaml
- gem: 'foo'
  git: 'http://some.git.url/foo.git'
  branch: 'bugfix'
```
causes an empty `ref` constraint to be added which breaks things. Looks like a copy & paste whoops. 