### PR TITLE
(PDK-511) Add strict checking for PDK unit test templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 
 | Key            | Description   |
 | :------------- |:--------------|
+|hiera_config|Sets the [`hiera_config`](http://rspec-puppet.com/documentation/configuration/#hiera_config) rspec-puppet parameter.|
+|mock_with|Defaults to `':mocha'`. Recommended to be set to `':rspec'`, which uses RSpec's built-in mocking library, instead of a third-party one.|
+|spec_overrides|An array of extra lines to add into your `spec_helper.rb`. Can be used as an alternative to `spec_helper_local`|
 |strict_level| Defines the [Puppet Strict configuration parameter](https://puppet.com/docs/puppet/5.4/configuration.html#strict). Defaults to `:warning`. Other values are: `:error` and `:off`. `:error` provides strictest level checking and is encouraged.|
 
 ## Further Notes <a name="notes"></a>

--- a/README.md
+++ b/README.md
@@ -123,7 +123,13 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |is_pe|Overrides the is_pe fact's value in the base template. Defaults to false.
 |macaddress|Overrides the macaddress fact's value in the base template. Defaults to "AA:AA:AA:AA:AA:AA".
 |extra_facts|List of extra facts to be added to the default_facts.yml file. They are in the form: "`name of fact`: `value of fact`"|
- 
+
+### spec/spec_helper.rb
+> The spec/spec_helper.rb file contains setup for rspec tests
+
+| Key            | Description   |
+| :------------- |:--------------|
+|strict_level| Defines the [Puppet Strict configuration parameter](https://puppet.com/docs/puppet/5.4/configuration.html#strict). Defaults to `:warning`. Other values are: `:error` and `:off`. `:error` provides strictest level checking and is encouraged.|
 
 ## Further Notes <a name="notes"></a>
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -556,3 +556,5 @@ spec/default_facts.yml:
   ipaddress: "172.16.254.254"
   is_pe: false
   macaddress: "AA:AA:AA:AA:AA:AA"
+spec/spec_helper.rb:
+  strict_level: ":warning"

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -37,7 +37,7 @@ RSpec.configure do |c|
   c.before :each do
     # set to strictest setting for testing
     # by default Puppet runs at warning level
-    Puppet.settings[:strict] = <%= @configs['strict_level'].to_sym %>
+    Puppet.settings[:strict] = <%= @configs['strict_level'] %>
   end
   <%- end -%>
 end

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -33,6 +33,13 @@ RSpec.configure do |c|
   <%- if @configs['hiera_config'] -%>
   c.hiera_config = <%= @configs['hiera_config'] %>
   <%- end -%>
+  <%- if @configs['strict_level'] -%>
+  c.before :each do
+    # set to strictest setting for testing
+    # by default Puppet runs at warning level
+    Puppet.settings[:strict] = <%= @configs['strict_level'].to_sym %>
+  end
+  <%- end -%>
 end
 <%- [@configs['spec_overrides']].flatten.compact.each do |line| -%>
 <%= line %>


### PR DESCRIPTION
Background: resource-api will check get values to see if they have been modified by canonicalize and will throw if Puppet strict is at :error level. 

This change ensures that tests are run at the highest level by default.