### PR TITLE
Remove Layout/IndentHeredoc as it is "broken" in conjunction with aut…

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -167,7 +167,6 @@ Rakefile:
     Layout/IndentArray:
     Layout/IndentAssignment:
     Layout/IndentHash:
-    Layout/IndentHeredoc:
     Layout/IndentationConsistency:
     Layout/IndentationWidth:
     Layout/InitialIndentation:

--- a/rubocop/cleanup_cops.yml
+++ b/rubocop/cleanup_cops.yml
@@ -24,7 +24,6 @@
 - Layout/IndentArray
 - Layout/IndentAssignment
 - Layout/IndentHash
-- Layout/IndentHeredoc
 - Layout/IndentationConsistency
 - Layout/IndentationWidth
 - Layout/InitialIndentation


### PR DESCRIPTION
…ocorrect

The example below shows how rubocop:auto_correct does not detect a failure
with `Layout/IndentHeredoc` due to a missing `EnforcedStyle`. Once we drop
ruby 2.1, we can update this to `squiggly` and be done with it.

```
david@davids:~/git/puppetlabs-resource_api$ bundle exec rake rubocop:auto_correct
Running RuboCop...
Inspecting 9 files
Parser::Source::Rewriter is deprecated.
Please update your code to use Parser::Source::TreeRewriter instead
..Auto-correction does not work for Layout/IndentHeredoc. Please configure EnforcedStyle. (from file: /home/david/git/puppetlabs-resource_api/spec/acceptance/server_spec.rb:7:16)
.......

9 files inspected, no offenses detected

1 warning:
Auto-correction does not work for Layout/IndentHeredoc. Please configure EnforcedStyle. (from file: /home/david/git/puppetlabs-resource_api/spec/acceptance/server_spec.rb:7:16)
david@davids:~/git/puppetlabs-resource_api$ bundle exec rake rubocop
Running RuboCop...
Inspecting 9 files
..C......

Offenses:

spec/acceptance/server_spec.rb:8:1: C: Layout/IndentHeredoc: Use 2 spaces for indentation in a heredoc by using some library(e.g. ActiveSupport's String#strip_heredoc). (https://github.com/bbatsov/ruby-style-guide#squiggly-heredocs)
include resource_api::agent, resource_api::server ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

9 files inspected, 1 offense detected
RuboCop failed!
david@davids:~/git/puppetlabs-resource_api$
```