### PR TITLE
(maint) exclude lib/ directory from Style/Documentation cop

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -460,6 +460,7 @@ Rakefile:
         Style/ClassVars:
         Style/ConstantName:
         Style/Documentation:
+          Exclude: [ 'lib/puppet/parser/functions/**/*' ]
         Style/DoubleNegation:
         Style/EndBlock:
         Style/FileName:


### PR DESCRIPTION
Currently, I'm working on adding Puppet Strings documentation to puppetlabs-mysql. When running rubocop on the module, after finishing a first pass, I got 3 warnings from the Style/Documentation cop that expects to see comments directly above Ruby modules. 
e.g.
```ruby
# This function does a cool thing
# Honestly!
module Puppet::Parser::Functions
...
```
Since documentation for Strings will be going inside the @docs or passed to the desc method for any file inside 'lib/', we should disable this requirement for that directory. 
e.g.
```ruby
module Puppet::Parser::Functions
  newfunction(:mysql_password, type: :rvalue, doc: <<-EOS
    @summary
      Hash a string as mysql's "PASSWORD()" function would do it
    @param [String] password Plain text password.
    @return [String] the mysql password hash from the clear text password.
    EOS
             ) do |args|
...
  end
end
```
We might consider disabling it altogether since we're only running Rubocop on lib/ as far as I know.