### PR TITLE
(maint) remove redundant require

### DIFF
--- a/object_templates/provider.erb
+++ b/object_templates/provider.erb
@@ -1,4 +1,3 @@
-require 'puppet/resource_api'
 require 'puppet/resource_api/simple_provider'
 
 # Implementation for the <%= name %> type using the Resource API.


### PR DESCRIPTION
The main Resource API is not required for loading a provider. Keep it
simple.