### PR TITLE
Default to mock with :rspec

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -1,3 +1,6 @@
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 
@@ -27,9 +30,6 @@ end
 
 RSpec.configure do |c|
   c.default_facts = default_facts
-  <%- if @configs['mock_with'] -%>
-  c.mock_with <%= @configs['mock_with'] %>
-  <%- end -%>
   <%- if @configs['hiera_config'] -%>
   c.hiera_config = <%= @configs['hiera_config'] %>
   <%- end -%>


### PR DESCRIPTION
Related to https://github.com/puppetlabs/pdk/issues/477

Testing with PDK 1.4.1, running with the templates and adding the `c.mock with :rspec` line at the bottom of the file is not resolving the deprecation message when running tests (like in TravisCI).

The solution that worked for me resolving the deprecation message was adding the mock configuration at the start of the file.

Additional changes should be handled by PDK `convert` if any migration issues are encountered
https://github.com/puppetlabs/puppetlabs_spec_helper#migration