### PR TITLE
(maint) Add global_env section to Travis configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 | :------------- |:--------------|
 | ruby versions  |Define the ruby versions on which you want your builds to be executed.|
 | bunder\_args   |Define any arguments you want to pass through to bundler. The default is `--without system_tests` which avoids installing unnessesary gems.|
-| env            |Allows you to set any environment variables for the travis build. Currently includes setting the Puppet gem version alongside the variable `CHECK` which determines what tests to run.|
+| env            |Allows you to add new travis job matrix entries based on the included environmnet variables, one per `env` entry; for example, for adding jobs with specific `PUPPET_GEM_VERSION` and/or `CHECK` values.  See the [Travis Environment Variables](https://docs.travis-ci.com/user/environment-variables) documentation for details.|
+| global_env     |Allows you to set global environment variables which will be defined for all travis jobs; for example, `PARALLEL_TEST_PROCESSORS` or `TIMEOUT`.  See the [Travis Global Environment Variables](https://docs.travis-ci.com/user/environment-variables/#Global-Variables) documentation for details.|
 |docker_sets     |Allows you to configure sets of docker to run your tests on. For example, if I wanted to run on a docker instance of Ubuntu I would add  `set: docker/ubuntu-14.04` to my docker\_sets attribute.|
 |docker_defaults |Defines what values are used as default when using the `docker_sets` definition. Includes ruby version, sudo being enabled, the distro, the services, the env variables and the script to execute.|
 |includes        |Ensures that the .travis file includes the following checks by default: Rubocop, Puppet Lint, Metadata Lint.|

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -31,9 +31,20 @@ rvm:
 <% @configs['ruby_versions'].each do |ruby_version| -%>
   - <%= ruby_version %>
 <% end -%>
+<% if @configs.has_key?('env') || @configs.has_key?('global_env') -%>
 env:
-<% @configs['env'].each do |env| -%>
-  - <%= env %>
+<%   if @configs.has_key?('global_env') -%>
+  global:
+<%     @configs['global_env'].each do |env| -%>
+    - <%= env %>
+<%     end -%>
+<%   end -%>
+<%   if @configs.has_key?('env') -%>
+  matrix:
+<%     @configs['env'].each do |env| -%>
+    - <%= env %>
+<%     end -%>
+<%   end -%>
 <% end -%>
 matrix:
   fast_finish: true


### PR DESCRIPTION
Allow configuration of Travis `global` environment variables through the addition of a new `global_env` section in the travis configuration.
The existing `env` section is modified to add its environment variables to the `matrix` section of Travis's `env` settings (to keep identical behavior to the existing functionality).
See https://docs.travis-ci.com/user/environment-variables/#Global-Variables