### PR TITLE
Added ability to set structured extra facts

### DIFF
--- a/moduleroot/spec/default_facts.yml.erb
+++ b/moduleroot/spec/default_facts.yml.erb
@@ -7,7 +7,6 @@ ipaddress: "<%= @configs['ipaddress'] %>"
 is_pe: <%= @configs['is_pe'] %>
 macaddress: "<%= @configs['macaddress'] %>"
 <% if !@configs['extra_facts'].nil? -%>
-<%   @configs['extra_facts'].each do |fact, value| -%>
-<%= fact %>: "<%= value %>"
-<%   end -%>
+<% require 'yaml' -%>
+<%= @configs['extra_facts'].to_yaml[4..-1] %>
 <% end -%>


### PR DESCRIPTION
Currently if you want extra facts that are structured it doesn't work as the value of the facts is just printed in ruby's `to_s` style. This fixes that.