### PR TITLE
Add a remove_includes configuration option

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -45,7 +45,7 @@ matrix:
       <%= key %>: <%= job[key].gsub(/@@SET@@/, set['set']) %>
 <%   end -%>
 <% end -%>
-<% (@configs['includes'] + (@configs['extras'] || [])).each do |job| -%>
+<% (@configs['includes'] - (@configs['remove_includes'] || []) + (@configs['extras'] || [])).each do |job| -%>
     -
 <%   job.keys.sort.each do |key| -%>
       <%= key %>: <%= job[key] %>


### PR DESCRIPTION
Prior to this commit, the user could not remove the default included checks
with configuration.

After this commit, the user can specify default checks that should be removed
in the remove_includes configuration setting in .sync.yml

This allows for a .sync.yml like the following that replaces check=spec with
check=parallel_spec.

```
.travis.yml:
  remove_includes:
    - env: CHECK=spec
    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
      rvm:  2.1.9
  includes:
    - env: CHECK=parallel_spec
    - env: PUPPET_GEM_VERSION="= 4.6.1" CHECK=parallel_spec
      rvm: 2.1.9
    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
      rvm: 2.1.9
```