### PR TITLE
Add a remove_includes configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |docker_sets     |Allows you to configure sets of docker to run your tests on. For example, if I wanted to run on a docker instance of Ubuntu I would add  `set: docker/ubuntu-14.04` to my docker\_sets attribute.|
 |docker_defaults |Defines what values are used as default when using the `docker_sets` definition. Includes ruby version, sudo being enabled, the distro, the services, the env variables and the script to execute.|
 |includes        |Ensures that the .travis file includes the following checks by default: Rubocop, Puppet Lint, Metadata Lint.|
+|remove_includes |Allows you to remove includes set in config_defaults.yml.|
 
 ### .yardopts
 

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -45,7 +45,7 @@ matrix:
       <%= key %>: <%= job[key].gsub(/@@SET@@/, set['set']) %>
 <%   end -%>
 <% end -%>
-<% (@configs['includes'] + (@configs['extras'] || [])).each do |job| -%>
+<% (@configs['includes'] - (@configs['remove_includes'] || []) + (@configs['extras'] || [])).each do |job| -%>
     -
 <%   job.keys.sort.each do |key| -%>
       <%= key %>: <%= job[key] %>


### PR DESCRIPTION
Prior to this commit, the user could not remove the default included checks
with configuration.

After this commit, the user can specify default checks that should be removed
in the remove_includes configuration setting in .sync.yml

This allows for a .sync.yml like the following that replaces check=spec with
check=parallel_spec.

```
.travis.yml:
  remove_includes:
    - env: CHECK=spec
    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
      rvm:  2.1.9
  includes:
    - env: CHECK=parallel_spec
    - env: PUPPET_GEM_VERSION="= 4.6.1" CHECK=parallel_spec
      rvm: 2.1.9
    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
      rvm: 2.1.9
```