### PR TITLE
Default to parallel specs in CI

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -52,8 +52,8 @@
     - env: CHECK="syntax lint"
     - env: CHECK=metadata_lint
     - env: CHECK=release_checks
-    - env: CHECK=spec
-    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
+    - env: CHECK=parallel_spec
+    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
       rvm:  2.1.9
 .yardopts:
   markup: markdown
@@ -68,16 +68,16 @@ appveyor.yml:
       CHECK: rubocop
     - PUPPET_GEM_VERSION: ~> 4.0
       RUBY_VERSION: 21
-      CHECK: spec
+      CHECK: parallel_spec
     - PUPPET_GEM_VERSION: ~> 4.0
       RUBY_VERSION: 21-x64
-      CHECK: spec
+      CHECK: parallel_spec
     - PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24
-      CHECK: spec
+      CHECK: parallel_spec
     - PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24-x64
-      CHECK: spec
+      CHECK: parallel_spec
   test_script:
     - bundle exec rake %CHECK%
 Rakefile:
@@ -558,13 +558,13 @@ Gemfile:
     ruby_versions:
       '2.1.9':
         checks:
-          - spec
+          - parallel_spec
         puppet_version: '~> 4.0'
       '2.4.4':
         checks:
           - 'syntax lint metadata_lint'
           - rubocop
-          - spec
+          - parallel_spec
         puppet_version: '~> 5.5'
     # beaker: true
 spec/default_facts.yml:


### PR DESCRIPTION
Prior to this commit, we ran `rake spec` instead of
`rake parallel_spec`.  Since every travis, appveyor, and
gitlab ci all provide at least 2 cores running in parallel
can reduce runtimes.

After this commit, we default to running parallel_spec.