### PR TITLE
Add quotes around the spec_helper's hiera_config

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -34,7 +34,7 @@ end
 RSpec.configure do |c|
   c.default_facts = default_facts
   <%- if @configs['hiera_config'] -%>
-  c.hiera_config = <%= @configs['hiera_config'] %>
+  c.hiera_config = "<%= @configs['hiera_config'] %>"
   <%- end -%>
   <%- if @configs['strict_level'] -%>
   c.before :each do


### PR DESCRIPTION
Prior to this PR, the value for `spec_helper.rb` `hiera_config` was
not wrapped in quotes. It resulted in a failure when using the
`hiera_config` option as there is no `spec` object defined. This PR
adds quotes around the value in the template since it should always be a string.