### PR TITLE
(PDK-967) Add an option to specify additional lines in Rakefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 | :------------- |:--------------|
 |default\_disabled\_lint\_checks| Defines any checks that are to be disabled by default when running lint checks. As default we disable the `--relative` lint check, which compares the module layout relative to the module root. |
 |extra\_disabled\_lint\_checks| Defines any checks that are to be disabled as extras when running lint checks. No defaults are defined for this configuration. |
+|extras|An array of extra lines to add into your Rakefile|
 
 ### .rubocop.yml
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -83,6 +83,7 @@ appveyor.yml:
 Rakefile:
   default_disabled_lint_checks:
     - 'relative'
+  extras: []
 .rubocop.yml:
   selected_profile: strict
   default_configs: &default_configs

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -16,3 +16,7 @@ import '<%= item %>'
 <% checks.each do |check| -%>
 PuppetLint.configuration.send('<%= check %>')
 <% end -%>
+
+<%- [@configs['extras']].flatten.compact.each do |line| -%>
+<%= line %>
+<%- end -%>


### PR DESCRIPTION
This adds an `extras` configuration option to allow for specifying arbitrary lines to the Rakefile. This is to enable adding additional requires and configuration options like
`MetadataJsonLint.options.strict_license`.