### PR TITLE
Add an option to remove default includes in .travis.yml and .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following is a description and explaination of each of the keys within confi
 | Key               | Description   |
 | :-----------------|:--------------|
 | paths             | Defines which files or paths for git to ignore or untrack. (see the [gitignore](https://git-scm.com/docs/gitignore) documentation). The default configuration helps to set up commonly ignored or untracked files in a module project.
+| excludes           | Defined which files or paths for git that should not be ignored or untracked. This setting is used to override the default ignored paths. |
 
 ### .pdkignore
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |docker_sets     |Allows you to configure sets of docker to run your tests on. For example, if I wanted to run on a docker instance of Ubuntu I would add  `set: docker/ubuntu-14.04` to my docker\_sets attribute.|
 |docker_defaults |Defines what values are used as default when using the `docker_sets` definition. Includes ruby version, sudo being enabled, the distro, the services, the env variables and the script to execute.|
 |includes        |Ensures that the .travis file includes the following checks by default: Rubocop, Puppet Lint, Metadata Lint.|
+|excludes        |Ensures that the .travis file does not include checks listed in this array. Used to override a default included check.|
 
 ### .yardopts
 

--- a/moduleroot/.gitignore.erb
+++ b/moduleroot/.gitignore.erb
@@ -1,3 +1,3 @@
-<% (@configs['required'] + (@configs['paths'] || [])).uniq.each do |path| -%>
+<% (@configs['required'] + (@configs['paths'] || []) - (@configs['excludes'] || [])).uniq.each do |path| -%>
 <%= path %>
 <% end -%>

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -45,7 +45,7 @@ matrix:
       <%= key %>: <%= job[key].gsub(/@@SET@@/, set['set']) %>
 <%   end -%>
 <% end -%>
-<% (@configs['includes'] + (@configs['extras'] || [])).each do |job| -%>
+<% (@configs['includes'] + (@configs['extras'] || []) - (@configs['excludes'] || [])).each do |job| -%>
     -
 <%   job.keys.sort.each do |key| -%>
       <%= key %>: <%= job[key] %>


### PR DESCRIPTION
This adds an `excludes` option to remove `includes` from the checks. This enables the .sync.yml to remove some of the default checks to do things like using parallel_spec instead of spec. 

This also adds the same option to the `.gitignore`.