### PR TITLE
(MODULES-6891) - Enable puppet 5 installation when using beaker-puppet_install_helper on travis

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -45,7 +45,7 @@
     sudo: required
     dist: trusty
     services: docker
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=@@SET@@
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=@@SET@@
     script: bundle exec rake beaker
   includes:
     - env: CHECK=rubocop


### PR DESCRIPTION
Adding: BEAKER_PUPPET_COLLECTION=puppet5 to config_defaults.yml

Currently using the config_defaults.yml we are installing the puppet 5 gem. However when puppet-agent is actually installing using `beaker-puppet_install_helper` the value defaults to pc1 therefore it is installing puppet-agent  1.10.12-1. By setting this variable it installs puppet-agent.x86_64 0:5.5.1-1. I have tested these changes locally to ensure that they work. 