### PR TITLE
(PDK-681) Remove puppet-blacksmith

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -526,11 +526,6 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
-      - gem: puppet-blacksmith
-        version: '~> 3.4'
-        require: false
-        platforms:
-          - ruby
     # ':system_tests':
     #   - gem: 'puppet-module-posix-system-r#{minor_version}'
     #     platforms: ruby


### PR DESCRIPTION
As of https://github.com/puppetlabs/puppet-module-gems/pull/65 puppet-blacksmith is carried in the puppet-module-gems, and does not need to be referenced here. This allows PDK users to override the pin with their own requirements.