### PR TITLE
(PDK-962) default to :rspec mocking

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -1,8 +1,6 @@
-<%- if @configs['mock_with'] -%>
 RSpec.configure do |c|
-  c.mock_with <%= @configs['mock_with'] %>
+  c.mock_with <%= @configs['mock_with'] || ':rspec' %>
 end
-<%- end -%>
 
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'


### PR DESCRIPTION
Folks still can set `mock_with` in their `.sync.yml` to choose to stay
with mocha.