### PR TITLE
Addition of global_env section alongside configuration and docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 | :------------- |:--------------|
 | ruby versions  |Define the ruby versions on which you want your builds to be executed.|
 | bunder\_args   |Define any arguments you want to pass through to bundler. The default is `--without system_tests` which avoids installing unnessesary gems.|
-| env            |Allows you to set any environment variables for the travis build. Currently includes setting the Puppet gem version alongside the variable `CHECK` which determines what tests to run.|
+| env            |Allows you to add new travis job matrix entries based on the included environmnet variables, one per `env` entry; for example, for adding jobs with specific `PUPPET_GEM_VERSION` and/or `CHECK` values.  See the [Travis Environment Variables](https://docs.travis-ci.com/user/environment-variables) documentation for details.|
+| global_env     |Allows you to set global environment variables which will be defined for all travis jobs; for example, `PARALLEL_TEST_PROCESSORS` or `TIMEOUT`.  See the [Travis Global Environment Variables](https://docs.travis-ci.com/user/environment-variables/#Global-Variables) documentation for details.|
 |docker_sets     |Allows you to configure sets of docker to run your tests on. For example, if I wanted to run on a docker instance of Ubuntu I would add  `set: docker/ubuntu-14.04` to my docker\_sets attribute.|
 |docker_defaults |Defines what values are used as default when using the `docker_sets` definition. Includes ruby version, sudo being enabled, the distro, the services, the env variables and the script to execute.|
 |includes        |Ensures that the .travis file includes the following checks by default: Rubocop, Puppet Lint, Metadata Lint.|

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -35,8 +35,8 @@
 .travis.yml:
   ruby_versions:
     - 2.4.1
-  env:
-    - PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
+  global_env:
+    - BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_GEM_VERSION="~> 5.0"
   bundler_args: --without system_tests
   docker_sets:
   docker_defaults:

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -31,9 +31,20 @@ rvm:
 <% @configs['ruby_versions'].each do |ruby_version| -%>
   - <%= ruby_version %>
 <% end -%>
+<% if @configs.has_key?('env') || @configs.has_key?('global_env') -%>
 env:
-<% @configs['env'].each do |env| -%>
-  - <%= env %>
+<%   if @configs.has_key?('global_env') -%>
+  global:
+<%     @configs['global_env'].each do |env| -%>
+    - <%= env %>
+<%     end -%>
+<%   end -%>
+<%   if @configs.has_key?('env') -%>
+  matrix:
+<%     @configs['env'].each do |env| -%>
+    - <%= env %>
+<%     end -%>
+<%   end -%>
 <% end -%>
 matrix:
   fast_finish: true


### PR DESCRIPTION
Updates the global configuration to use the beaker_puppet_collection to ensure we are testing on Puppet 5, also updated to the correct the puppet 4 run, in conjunction with the changes jearls introduced.

```
174 --- .travis.yml 2018-05-10 15:12:25.076285955 +0100
175 +++ .travis.yml.pdknew  2018-05-11 13:17:50.767612000 +0100
176 @@ -16,7 +16,9 @@
177  rvm:
178    - 2.4.1
179  env:
180 -  - PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
181 +  global:
182 +    - BEAKER_PUPPET_COLLECTION=puppet5
183 +    - PARALLEL_TEST_PROCESSORS=16
184  matrix:
185    fast_finish: true
186    include:
187 @@ -47,7 +49,7 @@
188      -
189        env: CHECK=spec
190      -
191 -      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
192 +      env: BEAKER_PUPPET_COLLECTION=pc1 CHECK=spec
193        rvm: 2.1.9
194  branches:
195    only:
```