### PR TITLE
(PDK-986) Only run parts of release_check task

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -51,7 +51,7 @@
     - env: CHECK=rubocop
     - env: CHECK="syntax lint"
     - env: CHECK=metadata_lint
-    - env: CHECK=release_checks
+    - env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file"
     - env: CHECK=spec
     - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
       rvm:  2.1.9
@@ -60,6 +60,8 @@
 appveyor.yml:
   appveyor_bundle_install: "bundle install --jobs 4 --retry 2 --without system_tests"
   matrix:
+    - RUBY_VERSION: 24-x64
+      CHECK: "check:symlinks check:git_ignore check:dot_underscore check:test_file"
     - RUBY_VERSION: 24-x64
       CHECK: "syntax lint"
     - RUBY_VERSION: 24-x64
@@ -562,6 +564,7 @@ Gemfile:
         puppet_version: '~> 4.0'
       '2.4.4':
         checks:
+          - 'check:symlinks check:git_ignore check:dot_underscore check:test_file'
           - 'syntax lint metadata_lint'
           - rubocop
           - spec


### PR DESCRIPTION
Prior to this commit, we duplicated work because release_checks
runs lint and spec tests which we do elsewhere in the .travis
matrix.

After this commit, we run just the tasks we are interested in.