### PR TITLE
(PDK-987) Save CI resources / reduce developer feedback time

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -48,8 +48,7 @@
     env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=@@SET@@
     script: bundle exec rake beaker
   includes:
-    - env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file"
-    - env: CHECK=rubocop
+    - env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     - env: CHECK=parallel_spec
     - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
       rvm: 2.1.9
@@ -59,9 +58,7 @@ appveyor.yml:
   appveyor_bundle_install: "bundle install --jobs 4 --retry 2 --without system_tests"
   matrix:
     - RUBY_VERSION: 24-x64
-      CHECK: "syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file"
-    - RUBY_VERSION: 24-x64
-      CHECK: rubocop
+      CHECK: "syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     - PUPPET_GEM_VERSION: ~> 4.0
       RUBY_VERSION: 21
       CHECK: parallel_spec
@@ -558,8 +555,7 @@ Gemfile:
         puppet_version: '~> 4.0'
       '2.4.4':
         checks:
-          - 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file'
-          - rubocop
+          - 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'
           - parallel_spec
         puppet_version: '~> 5.5'
     # beaker: true

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -48,10 +48,8 @@
     env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=@@SET@@
     script: bundle exec rake beaker
   includes:
+    - env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file"
     - env: CHECK=rubocop
-    - env: CHECK="syntax lint"
-    - env: CHECK=metadata_lint
-    - env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file"
     - env: CHECK=parallel_spec
     - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
       rvm: 2.1.9
@@ -61,11 +59,7 @@ appveyor.yml:
   appveyor_bundle_install: "bundle install --jobs 4 --retry 2 --without system_tests"
   matrix:
     - RUBY_VERSION: 24-x64
-      CHECK: "check:symlinks check:git_ignore check:dot_underscore check:test_file"
-    - RUBY_VERSION: 24-x64
-      CHECK: "syntax lint"
-    - RUBY_VERSION: 24-x64
-      CHECK: metadata_lint
+      CHECK: "syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file"
     - RUBY_VERSION: 24-x64
       CHECK: rubocop
     - PUPPET_GEM_VERSION: ~> 4.0
@@ -564,8 +558,7 @@ Gemfile:
         puppet_version: '~> 4.0'
       '2.4.4':
         checks:
-          - 'check:symlinks check:git_ignore check:dot_underscore check:test_file'
-          - 'syntax lint metadata_lint'
+          - 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file'
           - rubocop
           - parallel_spec
         puppet_version: '~> 5.5'


### PR DESCRIPTION
Prior to this PR, we spent quite a bit of time spinning up containers and installing software instead of actually checking anything.  

After this PR, we get quicker feedback and save resources on our various free CI providers by running more checks at the same time instead of in new containers.  

Example of Travis before ( 311 seconds ): 
![image](https://user-images.githubusercontent.com/513998/40029149-c5650c4a-5797-11e8-9a31-044e058771e0.png)

Example of Travis after ( 66 seconds ): 
![image](https://user-images.githubusercontent.com/513998/40029348-07549700-5799-11e8-9516-98e05886cca1.png)

Specifically Travis notes it only takes 2.89 seconds to run all checks:
![image](https://user-images.githubusercontent.com/513998/40029346-fe34e846-5798-11e8-8537-9bcf9ab7463e.png)

Example Gitlab CI before: 
![image](https://user-images.githubusercontent.com/513998/40029252-49fa13ec-5798-11e8-8599-d379e12dc6c0.png)

Example Gitlab CI After:
![image](https://user-images.githubusercontent.com/513998/40029266-5ada1c7a-5798-11e8-9799-2bdf5f9ebacd.png)
