### PR TITLE
Add option to remove default paths from gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following is a description and explaination of each of the keys within confi
 | Key               | Description   |
 | :-----------------|:--------------|
 | paths             | Defines which files or paths for git to ignore or untrack. (see the [gitignore](https://git-scm.com/docs/gitignore) documentation). The default configuration helps to set up commonly ignored or untracked files in a module project.
+|remove_paths       | Allows you to remove default paths set in config_defaults.yml.|
 
 ### .gitlab-ci.yml
 

--- a/moduleroot/.gitignore.erb
+++ b/moduleroot/.gitignore.erb
@@ -1,3 +1,3 @@
-<% (@configs['required'] + (@configs['paths'] || [])).uniq.each do |path| -%>
+<% (@configs['required'] - (@configs['remove_paths'] || []) + (@configs['paths'] || [])).uniq.each do |path| -%>
 <%= path %>
 <% end -%>


### PR DESCRIPTION
This PR adds a `remove_paths` option for the `.gitignore` to remove a path specified in the `config_defaults.yml`. The name of the option is consistent with #67. 

An example configuration is below. 

~~~
.gitignore:
  paths:
    - checksums.json
  remove_paths:
    - /spec/fixtures/manifests/
~~~

Resulting in the following removal of the default path.

~~~
--- .gitignore  2018-05-16 15:57:10.000000000 -0700
+++ .gitignore.pdknew   2018-05-17 10:09:14.674529000 -0700
@@ -14,7 +14,6 @@
 /junit/
 /log/
 /pkg/
-/spec/fixtures/manifests/
 /spec/fixtures/modules/
 /tmp/
 /vendor/
~~~