### PR TITLE
(MODULES-7184) replace parallel_spec with spec

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -49,8 +49,8 @@
     script: bundle exec rake beaker
   includes:
     - env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
-    - env: CHECK=parallel_spec
-    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
+    - env: CHECK=spec
+    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
       rvm: 2.1.9
   deploy: true
   user: 'puppet'
@@ -63,16 +63,16 @@ appveyor.yml:
       CHECK: "syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     - PUPPET_GEM_VERSION: ~> 4.0
       RUBY_VERSION: 21
-      CHECK: parallel_spec
+      CHECK: spec
     - PUPPET_GEM_VERSION: ~> 4.0
       RUBY_VERSION: 21-x64
-      CHECK: parallel_spec
+      CHECK: spec
     - PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24
-      CHECK: parallel_spec
+      CHECK: spec
     - PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24-x64
-      CHECK: parallel_spec
+      CHECK: spec
   test_script:
     - bundle exec rake %CHECK%
 Rakefile:
@@ -556,12 +556,12 @@ Gemfile:
     ruby_versions:
       '2.1.9':
         checks:
-          - parallel_spec
+          - spec
         puppet_version: '~> 4.0'
       '2.4.4':
         checks:
           - 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'
-          - parallel_spec
+          - spec
         puppet_version: '~> 5.5'
     # beaker: true
 spec/default_facts.yml:


### PR DESCRIPTION
parallel_spec and bundler 1.16.2 are not playing nicely. The new bundler version was released yesterday and now checks that use parallel_spec are failing. Not sure if this is a permanent solution or not but it is definitely the easiest solution at this point and it should get things green again. Another equally easy option would be to remove the bundler update from the before_install array, but that seems like it would have much more of an impact.