### PR TITLE
(MAINT) Remove gem update bundler from before_install

### DIFF
--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -36,7 +36,6 @@ before_script:
   - bundle -v
   - rm Gemfile.lock || true
   - gem update --system
-  - gem update bundler
   - gem --version
   - bundle -v
   - bundle install <%= configs['bundler_args'] %>

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -21,7 +21,6 @@ before_install:
   - bundle -v
   - rm -f Gemfile.lock
   - gem update --system
-  - gem update bundler
   - gem --version
   - bundle -v
 script:


### PR DESCRIPTION
Bundler comes with rubygems now so it's already updated and
doesn't need to be updated again.

It also seems to actually cause failures in travis CI to
run gem update bundler possibly because it's updating something
it shouldn't on what was already installed with rubygems.

Resolves issues that look like:

```
/home/travis/.rvm/gems/ruby-2.4.1/bin/bundle:23:in `load': cannot load such
file --
/home/travis/.rvm/rubies/ruby-2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.16.2/exe/bundle
(LoadError)
from /home/travis/.rvm/gems/ruby-2.4.1/bin/bundle:23:in `<inmain>'
from /home/travis/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
from /home/travis/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooksble_hooks:15:in
`<main>'
```