### PR TITLE
Add option to specify except branches in .travis.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |docker_defaults |Defines what values are used as default when using the `docker_sets` definition. Includes ruby version, sudo being enabled, the distro, the services, the env variables and the script to execute.|
 |includes        |Ensures that the .travis file includes the following checks by default: Rubocop, Puppet Lint, Metadata Lint.|
 |remove_includes |Allows you to remove includes set in config_defaults.yml.|
+|branches        |Allows you to specify the only branches that travis will run builds on. The default branches are `master` and `/^v\d/`. |
+|branches_except |Allows you to specify branches that travis will not build on.|
+|remove_branches |Allows you to remove default branches set in config_defaults.yml.|
 
 ### .yardopts
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -55,6 +55,9 @@
       rvm: 2.1.9
   deploy: true
   user: 'puppet'
+  branches:
+    - master
+    - /^v\d/
 .yardopts:
   markup: markdown
 appveyor.yml:

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -71,12 +71,16 @@ matrix:
 <%   end -%>
 <% end -%>
 branches:
+<% if ((@configs['branches'] || []) - (@configs['remove_branches'] || [])).any? -%>
   only:
-    - master
-    - /^v\d/
-<% if @configs['branches'] -%>
-<%   @configs['branches'].each do |branch| -%>
-    - <%= branch %>
+<%   (@configs['branches'] - (@configs['remove_branches'] || [])).each do |branch| -%>
+    - <%= branch %> 
+<%   end -%>
+<% end -%>
+<% if @configs['branches_except'] -%>
+  except:
+<%   @configs['branches_except'].each do |branch| -%>
+    - <%= branch %> 
 <%   end -%>
 <% end -%>
 notifications:


### PR DESCRIPTION
Currently, there are two branches are hardcoded to be included in the `.travis.yml`. This PR moves those branches into the`config_defaults.yml` and adds an option to remove those default
branches. It also includes an option to specify travis's `except` branch option.

With this, you can now have a more complex configuration for specifying which branches should be included in the `.travis.yml`. Below are a few examples. 

Only use an `except`:

~~~
.travis.yml:
  remove_branches:
    - master
    - /^v\d/
  branches_except:
    - /^mergeup.*$/
~~~

Results in

~~~
branches:
  except:
    - /^mergeup.*$/
~~~

Remove one of the default branches and add another branch.

~~~
.travis.yml
   remove_branches:
      - /^v\d/
   branches:
      - development
~~~

Results in

~~~
branches:
  only:
    - master
    - development
~~~