### PR TITLE
(FIXUP) Fix rubocop validation failure for new provider spec tests

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -44,6 +44,23 @@ RSpec.configure do |c|
   end
   <%- end -%>
 end
+
+def ensure_module_defined(name)
+  name_parts = name.split('::')
+
+  lastmod = Object
+
+  name_parts.each do |modname|
+    lastmod = if lastmod.const_defined?(modname)
+                lastmod.const_get(modname)
+              else
+                lastmod.const_set(modname, Module.new)
+              end
+  end
+
+  lastmod
+end
+
 <%- [@configs['spec_overrides']].flatten.compact.each do |line| -%>
 <%= line %>
 <%- end -%>

--- a/object_templates/provider_spec.erb
+++ b/object_templates/provider_spec.erb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
-# TODO: needs some cleanup/helper to avoid this misery
-module Puppet::Provider::<%= provider_class %>; end
+ensure_module_defined('Puppet::Provider::<%= provider_class %>')
 require 'puppet/provider/<%= name %>/<%= name %>'
 
 RSpec.describe Puppet::Provider::<%= provider_class %>::<%= provider_class %> do


### PR DESCRIPTION
This should fix the acceptance test failures on PDK master