### PR TITLE
Fix newline warning in updated spec_helper and improve pre-merge CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 sudo: false
 dist: trusty
-language: c
+language: generic
 before_install:
   - wget https://apt.puppetlabs.com/puppet5-release-trusty.deb
   - sudo dpkg -i puppet5-release-trusty.deb
@@ -9,5 +9,15 @@ before_install:
   - sudo apt-get install pdk
 script:
   - '.travis/test_script.sh'
+branches:
+  only:
+    - master
 notifications:
   email: false
+  hipchat:
+    rooms:
+      secure: pXZo1noFzXPz4PN+f2jNUjBGxRnv3TBFh6n673/Rp6GO0RVh1zOAv7udzR9Pj84kOfFnRVg8zH98GR8rNLXZkNWhrwxXKiF8YzZhDfdm9EXUW05LY9AfJUw0Sc8iqPqtawBNzAMQolXFOnCMdVCl481b3vsKVyyh9HvfNe3eOPvQs7TsTpcvUPZQvMptIUDEYJQYBOklDVFYoT/mzTYFOTmVTtfzif6orYfzxEeDgN1gy/OcS6Ben66tKS4rzpxTLxKjg8mTUsBlOpx0hOy9KXcGErSpYMiRTwpTsftO02+c5xANobF4tVt6c8uSicZZ0yTLZEAUnnT1F0L4L/DKVH5fygDNgqt8bBNE5jt4QXAWQqBeNP9gKHGSSn15eMrhGRWNpp8wxzDwgFQ1byHWR83TW0/uH2nVdqVKdwSV8QAyD/pd3F5wh7uCaHdJulsFkdgMh7fC9GvLaNbyxosTUNtDTFUO/UN1ZUsWPbBBz28mIx50iIp03oLbN4LrDbTJqRPZ+etPqYJ292FC8ifiRQI7V9zpNMcIBO26EgboeNTqE7GQ403tYMG/L5XdVhGl7tEBqfFCEIQBWwywDa5xTpBjBex0IGb0mqsdHJ1iK8Qy2yJwXIfcsFkIto0Hq65Zm+HvMm+1ep/v6DAsyYVmNbwDGj7hXBVC8WHyxejnxeM=
+    template:
+      - '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}
+        (<a href="%{build_url}">Details</a> | <a href="%{compare_url}">PR/Diff</a>)'
+    format: html

--- a/.travis/fixtures/new_provider_sync.yml
+++ b/.travis/fixtures/new_provider_sync.yml
@@ -1,0 +1,7 @@
+---
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'puppet-resource_api'
+spec/spec_helper.rb:
+  mock_with: ':rspec'

--- a/.travis/test_script.sh
+++ b/.travis/test_script.sh
@@ -1,15 +1,40 @@
-PR_DIR=$PWD
+#!/bin/bash
+set -x # echo commands with vars expanded
+set -e # exit immediately on error
 
-pdk new module pr_new_modules --template-url=$PR_DIR --skip-interview
+TEMPLATE_PR_DIR=$PWD
 
-pdk new module normal_module --skip-interview
-cd normal_module
-pdk convert --template-url=$PR_DIR --skip-interview --force
+# This tricks PDK into testing this commit instead of whatever master is on this repo
+git update-ref refs/heads/master "$TRAVIS_COMMIT"
+
+pdk new module new_module --template-url="file://$TEMPLATE_PR_DIR" --skip-interview
+pushd new_module
+grep template < metadata.json
+cp "$TEMPLATE_PR_DIR/.travis/fixtures/new_provider_sync.yml" ./.sync.yml
+pdk update --force
+pdk new class new_module
+pdk new defined_type testtype
+pdk new provider testprovider
+pdk new task testtask
+pdk validate
+pdk test unit
+popd
+
+rm -f ~/.pdk/cache/answers.json
+
+pdk new module convert_from_release_tag --skip-interview
+pushd convert_from_release_tag
+grep template < metadata.json
+pdk convert --template-url="file://$TEMPLATE_PR_DIR" --skip-interview --force
 cat convert_report.txt
+popd
 
-cd $PR_DIR
+rm -f ~/.pdk/cache/answers.json
+
 git clone --depth=1 --branch=master https://github.com/puppetlabs/pdk-templates.git ../master-pdk-templates
-pdk new module pr_diff --template-url=$PR_DIR/../master-pdk-templates --skip-interview
-cd pr_diff
-pdk convert --template-url=$PR_DIR --skip-interview --force
+pdk new module convert_from_master --template-url="file://$TEMPLATE_PR_DIR/../master-pdk-templates" --skip-interview
+pushd convert_from_master
+grep template < metadata.json
+pdk convert --template-url="file://$TEMPLATE_PR_DIR" --skip-interview --force
 cat convert_report.txt
+popd

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -61,6 +61,7 @@ def ensure_module_defined(name)
   lastmod
 end
 
+# 'spec_overrides' from sync.yml will appear below this line
 <%- [@configs['spec_overrides']].flatten.compact.each do |line| -%>
 <%= line %>
 <%- end -%>

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -45,20 +45,11 @@ RSpec.configure do |c|
   <%- end -%>
 end
 
-def ensure_module_defined(name)
-  name_parts = name.split('::')
-
-  lastmod = Object
-
-  name_parts.each do |modname|
-    lastmod = if lastmod.const_defined?(modname)
-                lastmod.const_get(modname)
-              else
-                lastmod.const_set(modname, Module.new)
-              end
+def ensure_module_defined(module_name)
+  module_name.split('::').reduce(Object) do |last_module, next_module|
+    last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module)
+    last_module.const_get(next_module)
   end
-
-  lastmod
 end
 
 # 'spec_overrides' from sync.yml will appear below this line


### PR DESCRIPTION
I can split this up into a couple PRs if we want, but this fixes the newly introduced "trailing newline" rubocop warning from #99 and significantly expands the Travis test suite for pdk-templates.

The new travis tests will generate a new module using pdk-templates from the PR, then generate a new instance of each time of module resource (class, provider, task, etc.), then run `pdk validate` and `pdk test unit` to make sure everything runs cleanly.

Steps 2 and 3 of the test suite continue to test that a module generated from the last release tag and from the current state of master can be converted to use the template from the PR.