### PR TITLE
revise Style/Documentation excludes

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -457,7 +457,9 @@ Rakefile:
         Style/ClassVars:
         Style/ConstantName:
         Style/Documentation:
-          Exclude: [ 'lib/puppet/parser/functions/**/*' ]
+          Exclude:
+          - 'lib/puppet/parser/functions/**/*'
+          - 'spec/**/*'
         Style/DoubleNegation:
         Style/EndBlock:
         Style/FileName:


### PR DESCRIPTION
The cop excludes `spec/**/*` by default, and should do so going
forward, to avoid false positives, as there is no requirement for
module/class documentation in specs.

Example of this change in action:

```
david@davids:~/git/puppetlabs-panos$ pdk new provider panos_address
pdk (INFO): Creating '/home/david/git/puppetlabs-panos/lib/puppet/provider/panos_address/panos_address.rb' from template.
pdk (INFO): Creating '/home/david/git/puppetlabs-panos/lib/puppet/type/panos_address.rb' from template.
pdk (INFO): Creating '/home/david/git/puppetlabs-panos/spec/unit/puppet/provider/panos_address/panos_address_spec.rb' from template.
pdk (INFO): Creating '/home/david/git/puppetlabs-panos/spec/unit/puppet/type/panos_address_spec.rb' from template.
david@davids:~/git/puppetlabs-panos$ pdk validate ruby
pdk (INFO): Running all available validators...
pdk (INFO): Using Ruby 2.4.4
pdk (INFO): Using Puppet 5.5.1
[✖] Checking Ruby code style (**/**.rb).
convention: rubocop: spec/unit/puppet/provider/panos_address/panos_address_spec.rb:4:1: Style/Documentation: Missing top-level module documentation comment.
david@davids:~/git/puppetlabs-panos$ vi .rubocop.yml
david@davids:~/git/puppetlabs-panos$ git diff .rubocop.yml
diff --git a/.rubocop.yml b/.rubocop.yml
index 7ed6225..faa6470 100644
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,6 +71,7 @@ RSpec/MessageSpies:
 Style/Documentation:
   Exclude:
   - lib/puppet/parser/functions/**/*
+  - spec/**/*
 Style/WordArray:
   EnforcedStyle: brackets
 Style/CollectionMethods:
david@davids:~/git/puppetlabs-panos$ pdk validate ruby
pdk (INFO): Using Ruby 2.4.4
pdk (INFO): Using Puppet 5.5.1
[✔] Checking Ruby code style (**/**.rb).
david@davids:~/git/puppetlabs-panos$ pdk --version
1.5.0
david@davids:~/git/puppetlabs-panos$
```