### PR TITLE
(maint) Add a note about the knockout_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The PDK Templates is the default templates repository for use with the [Puppet D
 * `moduleroot_init` templates get only deployed when the target file does not yet exist; use them to provide skeletons for files the developer needs to modify heavily.
 * `object_templates` templates are used by the various `new ...` commands for classes, defined types, etc.
 
-The PDK also absorbs the `config_defaults.yml` file to apply a set of default configurations to the module. Each top-level key in the file corresponds to a target file, and will be merged with the `:global` section at the top. Within the template evaluation the values are available under `@config`. In the module itself, you can override/amend the values by putting new values into `.sync.yml` in the module's root. The data for a target file also use `delete: true` and `unmanaged: true` to remove, or ignore the particular file.
+The PDK also absorbs the `config_defaults.yml` file to apply a set of default configurations to the module. Each top-level key in the file corresponds to a target file, and will be merged with the `:global` section at the top. Within the template evaluation the values are available under `@config`. In the module itself, you can override/amend the values by putting new values into `.sync.yml` in the module's root. You can remove default values by adding the [knockout prefix](https://www.rubydoc.info/gems/puppet/DeepMerge) of `---` to the value in the `.sync.yml`. The data for a target file also use `delete: true` and `unmanaged: true` to remove, or ignore the particular file. 
 
 * [Basic usage](#basic-usage)
 * [Config_default Values](#values)


### PR DESCRIPTION
Prior to this PR, there was no mention of the knockout_prefix
implemented in PDK-949. This PR adds a note about using the `---`
prefix in the `.sync.yml` to knock out values.