### PR TITLE
Add system_tests and add beaker-aws environment

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -529,25 +529,27 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
-    # ':system_tests':
-    #   - gem: 'puppet-module-posix-system-r#{minor_version}'
-    #     platforms: ruby
-    #   - gem: 'puppet-module-win-system-r#{minor_version}'
-    #     platforms:
-    #       - mswin
-    #       - mingw
-    #       - x64_mingw
-    #   - gem: beaker
-    #     version: '~> 3.13'
-    #     from_env: BEAKER_VERSION
-    #   - gem: beaker-abs
-    #     from_env: BEAKER_ABS_VERSION
-    #     version: '~> 0.1'
-    #   - gem: beaker-pe
-    #   - gem: beaker-hostgenerator
-    #     from_env: BEAKER_HOSTGENERATOR_VERSION
-    #   - gem: beaker-rspec
-    #     from_env: BEAKER_RSPEC_VERSION
+    ':system_tests':
+      - gem: 'puppet-module-posix-system-r#{minor_version}'
+        platforms: ruby
+      - gem: 'puppet-module-win-system-r#{minor_version}'
+        platforms:
+          - mswin
+          - mingw
+          - x64_mingw
+      - gem: beaker
+        version: '~> 3.13'
+        from_env: BEAKER_VERSION
+      - gem: beaker-abs
+        from_env: BEAKER_ABS_VERSION
+        version: '~> 0.1'
+      - gem: beaker-pe
+      - gem: beaker-hostgenerator
+        from_env: BEAKER_HOSTGENERATOR_VERSION
+      - gem: beaker-rspec
+        from_env: BEAKER_RSPEC_VERSION
+      - gem: beaker-aws
+        from_env: BEAKER_AWS_VERSION
 .gitlab-ci.yml:
   defaults:
     cache:


### PR DESCRIPTION
Now that https://tickets.puppetlabs.com/browse/BKR-1464 has been resolved should be able to enable `system_tests` group.
Also due to issue with https://tickets.puppetlabs.com/browse/BKR-1483 it would be beneficial to allow `beaker-aws` to have environment variable for override