### PR TITLE
(GH#530) Change quotes around hiera_config to single quotes

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -34,7 +34,7 @@ end
 RSpec.configure do |c|
   c.default_facts = default_facts
   <%- if @configs['hiera_config'] -%>
-  c.hiera_config = "<%= @configs['hiera_config'] %>"
+  c.hiera_config = '<%= @configs['hiera_config'] %>'
   <%- end -%>
   <%- if @configs['strict_level'] -%>
   c.before :each do


### PR DESCRIPTION
Fixes the rubocop warning created by the change in #72, as reported in puppetlabs/pdk#530