### PR TITLE
Remove Layout/IndentHeredoc cop from default config

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -168,7 +168,6 @@ Rakefile:
     Layout/IndentArray:
     Layout/IndentAssignment:
     Layout/IndentHash:
-    Layout/IndentHeredoc:
     Layout/IndentationConsistency:
     Layout/IndentationWidth:
     Layout/InitialIndentation:

--- a/rubocop/cleanup_cops.yml
+++ b/rubocop/cleanup_cops.yml
@@ -24,7 +24,6 @@
 - Layout/IndentArray
 - Layout/IndentAssignment
 - Layout/IndentHash
-- Layout/IndentHeredoc
 - Layout/IndentationConsistency
 - Layout/IndentationWidth
 - Layout/InitialIndentation


### PR DESCRIPTION
The real solution requires ruby 2.4 to make use of the `<<~` operator.
As long as that is not universally available, this cop doesn't make
sense and is very annoying as its recommendation is not implementable.