### PR TITLE
(maint) Remove extra white space in .travis.yml branches

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -78,13 +78,13 @@ branches:
 <% if ((@configs['branches'] || []) - (@configs['remove_branches'] || [])).any? -%>
   only:
 <%   (@configs['branches'] - (@configs['remove_branches'] || [])).each do |branch| -%>
-    - <%= branch %> 
+    - <%= branch %>
 <%   end -%>
 <% end -%>
 <% if @configs['branches_except'] -%>
   except:
 <%   @configs['branches_except'].each do |branch| -%>
-    - <%= branch %> 
+    - <%= branch %>
 <%   end -%>
 <% end -%>
 notifications:


### PR DESCRIPTION
I left some extra spaces in #97. This PR removes those unnecessary spaces from each branch. 