### PR TITLE
(FM-7218) Changes to allow the use of parallel spec for the unit test…

### DIFF
--- a/moduleroot/appveyor.yml.erb
+++ b/moduleroot/appveyor.yml.erb
@@ -17,7 +17,11 @@ environment:
 <%- (@configs['matrix'] + (@configs['matrix_extras'] || [])).each do |matrix| -%>
     -
   <%- matrix.each do |key, value| -%>
+    <%- if (@configs['spec_type'] && value =~ %r{spec}) -%>
+      <%= key %>: <%= @configs['spec_type'] %>
+    <%- else -%>
       <%= key %>: <%= value %>
+    <%- end -%>
   <%- end -%>
 <%- end -%>
 matrix:


### PR DESCRIPTION
…’s to be overwritten.

The need for this change has arisen from the Java_KS module which is unable to successfully run parallel unit tests on appveyor. As such rather than disregard the test's or set them all to be run on spec I wish for the ability for a choice to be made within the .sync.yml files of each module of which spec type to use.

In order to make the desired changes you must add this to the .sync.yml:
```
appveyor.yml:
  spec_type: spec
```
I have tested this against both Java_KS and stdlib. Without the above code there are no changes while it's inclusion results in:
```
environment:
  matrix:
    -
      RUBY_VERSION: 24-x64
      CHECK: syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
    -
      PUPPET_GEM_VERSION: ~> 4.0
      RUBY_VERSION: 21
      CHECK: spec
    -
      PUPPET_GEM_VERSION: ~> 4.0
      RUBY_VERSION: 21-x64
      CHECK: spec
    -
      PUPPET_GEM_VERSION: ~> 5.0
      RUBY_VERSION: 24
      CHECK: spec
    -
      PUPPET_GEM_VERSION: ~> 5.0
      RUBY_VERSION: 24-x64
      CHECK: spec
```