### PR TITLE
Create ability to configure notifications

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -574,3 +574,4 @@ spec/default_facts.yml:
   macaddress: "AA:AA:AA:AA:AA:AA"
 spec/spec_helper.rb:
   strict_level: ":warning"
+notifications: true

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -87,8 +87,25 @@ branches:
     - <%= branch %> 
 <%   end -%>
 <% end -%>
+<% if @configs['notifications'] -%>
 notifications:
   email: false
+<%   if @configs['notifications']['custom'] -%>
+<%     @configs['notifications']['custom'].each do |notification, opts| -%>
+  <%= notification %>:
+<%       opts.each do |option, value| -%>
+<%         if value.is_a?(Array) -%>
+    <%= option %>:
+<%           value.each do |item| -%>
+      - "<%= item %>"
+<%           end -%>
+<%         else -%>    
+    <%= option %>: <%= value %>
+<%         end -%>
+<%       end -%>  
+<%     end -%>
+<%   end -%>
+<% end -%>  
 <% if @configs['deploy'] -%>
 deploy:
   provider: puppetforge


### PR DESCRIPTION
This gives users the ability to create custom notification settings for travis. This was brought about as the first Vox Pupuli module to use PDK was missing some notification settings in the `.travis.yml` file. I can't imagine we are the only ones who have custom notifications going to slack/mattermost/IRC/Rocket.Chat/etc.