### PR TITLE
fixing stage job pinning so that spec jobs fall into unit stage

### DIFF
--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -48,7 +48,7 @@ before_script:
 <%   configs['ruby_versions'].each do |ruby_version, options| -%>
 <%     options['checks'].each do |check| -%>
 <%= check %>-Ruby <%= ruby_version %>-Puppet <%= options['puppet_version'] %>:
-<%       if check == 'spec' -%>
+<%       if check =~ /spec/ -%>
   stage: unit
 <%       else -%>
   stage: syntax


### PR DESCRIPTION
Per conversation on slack w/ @dhollinger and @DavidS -
https://puppetcommunity.slack.com/archives/C113FRBRU/p1533844991000226
https://puppetcommunity.slack.com/archives/C113FRBRU/p1533845132000355
https://puppetcommunity.slack.com/archives/C113FRBRU/p1533845264000395

I think this will suffice, to drop any "default" or "custom" checks that match spec into the unit stage.