### PR TITLE
(FM-7398) - Update unit tests for Appveyor to test on Puppet 6 and ruby 2.5.0

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -79,6 +79,12 @@ appveyor.yml:
     - PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24-x64
       CHECK: parallel_spec
+    - PUPPET_GEM_VERSION: ~> 6.0
+      RUBY_VERSION: 25
+      CHECK: parallel_spec
+    - PUPPET_GEM_VERSION: ~> 6.0
+      RUBY_VERSION: 25-x64
+      CHECK: parallel_spec
   test_script:
     - bundle exec rake %CHECK%
 Rakefile:


### PR DESCRIPTION
This PR adds test matrices to test Puppet 6 on ruby 2.5.0. I have ran test on iis by rolling out these template changes and I can confirm they passed with no failures. 

<img width="1303" alt="screen shot 2018-09-20 at 12 01 04 pm" src="https://user-images.githubusercontent.com/20774767/45814319-2e8b5180-bccd-11e8-9de1-dd222f792f54.png">
