### PR TITLE
Remove concat_basedir fact

### DIFF
--- a/moduleroot/spec/default_facts.yml.erb
+++ b/moduleroot/spec/default_facts.yml.erb
@@ -2,7 +2,6 @@
 #
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
-concat_basedir: "<%= @configs['concat_basedir'] %>"
 ipaddress: "<%= @configs['ipaddress'] %>"
 is_pe: <%= @configs['is_pe'] %>
 macaddress: "<%= @configs['macaddress'] %>"


### PR DESCRIPTION
This fact has been unused since puppetlabs-concat 2.0 so it's safe to remove.