### PR TITLE
(maint) Prefer LF over CRLF line endings for .epp files

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -5,6 +5,7 @@
     '*.erb': 'eol=lf'
     '*.pp': 'eol=lf'
     '*.sh': 'eol=lf'
+    '*.epp': 'eol=lf'
 .gitignore:
   required: &ignorepaths
       - '.git/'


### PR DESCRIPTION
For consistent behaviour with erb templates.