### PR TITLE
Fail on broken spec_helper_local

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -7,11 +7,7 @@ end
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 
-begin
-  require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_local.rb'))
-rescue LoadError => loaderror
-  warn "Could not require spec_helper_local: #{loaderror.message}"
-end
+require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_local.rb'))
 
 include RspecPuppetFacts
 


### PR DESCRIPTION
Since we already check whether the file is there, a `LoadError` will only occur when there is a error in the `spec_helper_local`. A warning is not appropriate in this case, as it will usually only mean that there is another (now obscured) error later in the test run.