### PR TITLE
(GH-154) Fix appveyor double build

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -88,6 +88,8 @@ appveyor.yml:
       CHECK: parallel_spec
   test_script:
     - bundle exec rake %CHECK%
+  branches:
+    - master
 Rakefile:
   default_disabled_lint_checks:
     - 'relative'

--- a/moduleroot/appveyor.yml.erb
+++ b/moduleroot/appveyor.yml.erb
@@ -1,8 +1,18 @@
 ---
 version: 1.1.x.{build}
 branches:
+<% if ((@configs['branches'] || []) - (@configs['remove_branches'] || [])).any? -%>
   only:
-  - master
+<%   (@configs['branches'] - (@configs['remove_branches'] || [])).each do |branch| -%>
+    - <%= branch %>
+<%   end -%>
+<% end -%>
+<% if @configs['branches_except'] -%>
+  except:
+<%   @configs['branches_except'].each do |branch| -%>
+    - <%= branch %>
+<%   end -%>
+<% end -%>
 skip_commits:
   message: /^\(?doc\)?.*/
 clone_depth: 10

--- a/moduleroot/appveyor.yml.erb
+++ b/moduleroot/appveyor.yml.erb
@@ -1,5 +1,8 @@
 ---
 version: 1.1.x.{build}
+branches:
+  only:
+  - master
 skip_commits:
   message: /^\(?doc\)?.*/
 clone_depth: 10


### PR DESCRIPTION
The problem is described in #154.  This commit ensures only master and pr branches get build.