### PR TITLE
(PDK-1210) setting inherited const_defined lookup to false

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -44,7 +44,7 @@ end
 def ensure_module_defined(module_name)
   module_name.split('::').reduce(Object) do |last_module, next_module|
     last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module, false)
-    last_module.const_get(next_module)
+    last_module.const_get(next_module, false)
   end
 end
 

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -43,7 +43,7 @@ end
 
 def ensure_module_defined(module_name)
   module_name.split('::').reduce(Object) do |last_module, next_module|
-    last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module)
+    last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module, false)
     last_module.const_get(next_module)
   end
 end


### PR DESCRIPTION

If there is a top level module with same name as a type which gets loaded before the type gets defined.

This will trigger a false positive on the `last_module.const_defined?` check causing an `uninitialized constant` error.

This change will no longer do a recursive check and only care about the local namespace this way avoiding the false positive. 
