### PR TITLE
(PDK-1191) Gracefully handle default_fact YAML load errors

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -16,15 +16,19 @@ default_facts = {
   facterversion: Facter.version,
 }
 
-default_facts_path = File.expand_path(File.join(File.dirname(__FILE__), 'default_facts.yml'))
-default_module_facts_path = File.expand_path(File.join(File.dirname(__FILE__), 'default_module_facts.yml'))
+default_fact_files = [
+  File.expand_path(File.join(File.dirname(__FILE__), 'default_facts.yml')),
+  File.expand_path(File.join(File.dirname(__FILE__), 'default_module_facts.yml')),
+]
 
-if File.exist?(default_facts_path) && File.readable?(default_facts_path)
-  default_facts.merge!(YAML.safe_load(File.read(default_facts_path)))
-end
+default_fact_files.each do |f|
+  next unless File.exist?(f) && File.readable?(f) && File.size?(f)
 
-if File.exist?(default_module_facts_path) && File.readable?(default_module_facts_path)
-  default_facts.merge!(YAML.safe_load(File.read(default_module_facts_path)))
+  begin
+    default_facts.merge!(YAML.safe_load(File.read(f)))
+  rescue => e
+    RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
+  end
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
If the file exists but has been truncated, silently skip it as if it does not exist.
If the file exists but doesn't contain valid YAML, add a warning to the RSpec output and attempt to continue running the tests.

```
semirhage :0: pdk/foo (git:master → origin ↑5 ?:1!)$ ../bin/pdk test unit
pdk (INFO): Using Ruby 2.4.4
pdk (INFO): Using Puppet 6.0.3
[✔] Preparing to run the unit tests.
[✔] Running unit tests.
WARNING: Unable to load /home/tsharpe/code/puppetlabs/pdk/foo/spec/default_facts.yml: no implicit conversion of String into Hash
  Evaluated 9 tests in 0.311514725 seconds: 0 failures, 0 pending.
```