### PR TITLE
(maint) - Update travis.yml to default to ruby 2.5.1

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -36,14 +36,14 @@
   required: *ignorepaths
 .travis.yml:
   ruby_versions:
-    - 2.5.0
+    - 2.5.1
   global_env:
     - BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_GEM_VERSION="~> 6.0"
   bundler_args: --without system_tests
   docker_sets:
   docker_defaults:
     # values will replace @@SET@@ with the docker_sets' value
-    rvm: 2.5.0
+    rvm: 2.5.1
     sudo: required
     dist: trusty
     services: docker


### PR DESCRIPTION
Puppet 6 is now shipped with ruby 2.5.1 and not 2.5.0. Bumping the ruby version to reflect this.