### PR TITLE
add support for travis stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |docker_sets['set']| this should refrence the docker nodeset that you wish to run|
 |docker_sets['testmode']| this configueres the `BEAKER_TESTMODE` to use when testing the docker instance.  the two options are `apply` and `agent` if omitted `apply` is used by default|
 |docker_defaults |Defines what values are used as default when using the `docker_sets` definition. Includes ruby version, sudo being enabled, the distro, the services, the env variables and the script to execute.|
+|stages          |Allows you to specify order and conditions for travis-ci build stages. See [Specifying Stage Order and Conditions](https://docs.travis-ci.com/user/build-stages/#specifying-stage-order-and-conditions).|
 |includes        |Ensures that the .travis file includes the following checks by default: Rubocop, Puppet Lint, Metadata Lint.|
 |remove_includes |Allows you to remove includes set in config_defaults.yml.|
 |branches        |Allows you to specify the only branches that travis will run builds on. The default branches are `master` and `/^v\d/`. |

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -49,6 +49,19 @@ env:
 <%     end -%>
 <%   end -%>
 <% end -%>
+<% if @configs.has_key?('stages') -%>
+stages:
+<%   @configs['stages'].each do |stage| -%>
+<%     if stage.is_a?(String) -%>
+  - <%= stage %>
+<%     elsif stage.is_a?(Hash) -%>
+  -
+<%       stage.keys.sort.each do |key| -%>
+    <%= key %>: <%= stage[key] %>
+<%       end -%>
+<%     end -%>
+<%   end -%>
+<% end -%>
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Hi, this enables you to specify `stages` section within `.travis.yml`. Using stages is a way to group and run jobs in parallel in each stage, but sequential one stage after another. This way you don't need to run all expensive spec and beaker test cases if some cheap static code analysis, e.g. lint or rubocop was not successful.

May have a look on this example:
- [rtib/puppet-static_custom_facts integration](https://github.com/rtib/puppet-static_custom_facts/tree/integration) branch
- and its according [Travis-CI Build](https://travis-ci.org/rtib/puppet-static_custom_facts/builds/459059905)