### PR TITLE
(PDK-957) Exclude all development files from module builds

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -34,6 +34,20 @@
       - '.DS_Store'
 .pdkignore:
   required: *ignorepaths
+  paths:
+    - '/appveyor.yml'
+    - '/.fixtures.yml'
+    - '/Gemfile'
+    - '/.gitattributes'
+    - '/.gitignore'
+    - '/.gitlab-ci.yml'
+    - '/.pdkignore'
+    - '/Rakefile'
+    - '/.rspec'
+    - '/.rubocop.yml'
+    - '/.travis.yml'
+    - '/.yardopts'
+    - '/spec/'
 .travis.yml:
   ruby_versions:
     - 2.5.1


### PR DESCRIPTION
Trim down the module builds to just what they need to run on a production puppet master.