### PR TITLE
Fix rubygems-update for ruby older than 2.3 for travis and gitlab-ci

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -68,7 +68,7 @@
     - env: CHECK=parallel_spec
     - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
       rvm: 2.4.4
-    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
+    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec RUBYGEMS_VERSION=2.7.8
       rvm: 2.1.9
   deploy: true
   user: 'puppet'
@@ -594,6 +594,7 @@ Gemfile:
         checks:
           - parallel_spec
         puppet_version: '~> 4.0'
+        rubygems_version: '2.7.8'
       '2.4.4':
         checks:
           - 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'

--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -44,7 +44,7 @@ before_script:
   - bundle config mirror.http://rubygems.org/ <%= configs['rubygems_mirror'] %>
   - bundle config mirror.https://rubygems.org/ <%= configs['rubygems_mirror'] %>
 <% end -%>
-  - gem update --system
+  - gem update --system $RUBYGEMS_VERSION
   - gem --version
   - bundle -v
   - bundle install <%= configs['bundler_args'] %>
@@ -68,6 +68,9 @@ before_script:
     - bundle exec rake <%= check %>
   variables:
     PUPPET_GEM_VERSION: '<%= options['puppet_version'] %>'
+<%       if options['rubygems_version'] -%>
+    RUBYGEMS_VERSION: '<%= options['rubygems_version'] -%>'
+<%       end -%>
 <%       if options['allow_failure'] -%>
 <%         if options['allow_failure'].include?(check) -%>
   allow_failure: true

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -19,7 +19,7 @@ addons:
 before_install:
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system
+  - gem update --system $RUBYGEMS_VERSION
   - gem --version
   - bundle -v
 script:


### PR DESCRIPTION
After the upgrade of [rubygems-update](https://rubygems.org/gems/rubygems-update/versions/3.0.0) the travis and gitlab-ci jobs are broken with
```bash
# gem update --system
Updating rubygems-update
Fetching: rubygems-update-3.0.0.gem (100%)
ERROR:  Error installing rubygems-update:
    rubygems-update requires Ruby version >= 2.3.0.
ERROR:  While executing gem ... (Errno::ENOENT)
    No such file or directory @ dir_chdir - /usr/local/bundle/gems/rubygems-update-2.6.6
# ruby --version
ruby 2.1.9p490 (2016-03-30 revision 54437) [x86_64-linux]
```
This patch has fixed it with the installation of the latest compatible version.