### PR TITLE
improve travis-ci defaults to leverage build stages

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -81,9 +81,6 @@
       stage: static
     - env: CHECK="rubocop"
       stage: static
-    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec RUBYGEMS_VERSION=2.7.8 BUNDLER_VERSION=1.17.3
-      rvm: 2.1.9
-      stage: spec
     - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
       rvm: 2.4.4
       stage: spec

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -75,11 +75,7 @@
     script: bundle exec rake beaker
     stage: beaker
   includes:
-    - env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file"
-      stage: static
-    - env: CHECK="syntax lint metadata_lint"
-      stage: static
-    - env: CHECK="rubocop"
+    - env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
       stage: static
     - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
       rvm: 2.4.5

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -81,7 +81,7 @@
       rvm: 2.4.5
       stage: spec
     - env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
-      rvm: 2.5.1
+      rvm: 2.5.3
       stage: spec
     - env: DEPLOY_TO_FORGE=yes
       stage: deploy

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -54,10 +54,14 @@
     - '/.yardopts'
     - '/spec/'
 .travis.yml:
+  stages:
+    - static
+    - spec
+    - beaker
+    - name: deploy
+      if: tag =~ ^v\d
   ruby_versions:
     - 2.5.3
-  global_env:
-    - BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_GEM_VERSION="~> 6"
   bundler_args: --without system_tests
   docker_sets:
   docker_defaults:
@@ -66,13 +70,25 @@
     sudo: required
     dist: trusty
     services: docker
+    bundler_args: --with system_tests
     env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=@@SET@@ BEAKER_TESTMODE=@@TESTMODE@@
     script: bundle exec rake beaker
+    stage: beaker
   includes:
-    - env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
-    - env: CHECK=parallel_spec
-    - env: PUPPET_GEM_VERSION="~> 5" CHECK=parallel_spec
-      rvm: 2.4.5
+    - env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file"
+      stage: static
+    - env: CHECK="syntax lint metadata_lint"
+      stage: static
+    - env: CHECK="rubocop"
+      stage: static
+    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec RUBYGEMS_VERSION=2.7.8 BUNDLER_VERSION=1.17.3
+      rvm: 2.1.9
+      stage: spec
+    - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
+      rvm: 2.4.4
+      stage: spec
+    - env: DEPLOY_TO_FORGE=yes
+      stage: deploy
   deploy: true
   user: 'puppet'
   branches:

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -57,7 +57,7 @@
   stages:
     - static
     - spec
-    - beaker
+    - acceptance
     - name: deploy
       if: tag =~ ^v\d
   ruby_versions:
@@ -73,7 +73,7 @@
     bundler_args: --with system_tests
     env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=@@SET@@ BEAKER_TESTMODE=@@TESTMODE@@
     script: bundle exec rake beaker
-    stage: beaker
+    stage: acceptance
   includes:
     - env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
       stage: static

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -87,6 +87,9 @@
     - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
       rvm: 2.4.4
       stage: spec
+    - env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
+      rvm: 2.5.1
+      stage: spec
     - env: DEPLOY_TO_FORGE=yes
       stage: deploy
   deploy: true

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -82,7 +82,7 @@
     - env: CHECK="rubocop"
       stage: static
     - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.4
+      rvm: 2.4.5
       stage: spec
     - env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
       rvm: 2.5.1


### PR DESCRIPTION
Hi there, I'd propose some changes to travis-ci defaults. Main goal is to leverage build stages by default. Along with some maintenance and bug fixing the main changes in this PR are:
* (improvement) define stages: static, spec, beaker, deploy
* (feature) deploy stage is limited to version tag
* (maintenance) remove unnecessary global env
* (bugfix) add bundler_args "--with system_tests" to docker_defaults
* ~~(improvement) split static code analysis jobs to multiple jobs on static stage~~
* (improvement) move spec test jobs to spec stage
* (maintenance) replace default spec job with explicit Puppet 6 job
* (maintenance) order spec test jobs by major version
* (improvement) introduce deploy job on deploy stage

I've been using such a setup for some time now and would like to push them upstream. As an working example, have a look on
* my [puppet-geoip](https://github.com/rtib/puppet-geoip) module
* and its Travis-CI [Build](https://travis-ci.org/rtib/puppet-geoip/builds/470712801)
