### PR TITLE
(FM-7659) - Fix to pin Bundler for Puppet 4 Testing

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -68,7 +68,7 @@
     - env: CHECK=parallel_spec
     - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
       rvm: 2.4.4
-    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec RUBYGEMS_VERSION=2.7.8
+    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec RUBYGEMS_VERSION=2.7.8 BUNDLER_VERSION=1.17.3
       rvm: 2.1.9
   deploy: true
   user: 'puppet'

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -17,6 +17,9 @@ addons:
 <%   end -%>
 <% end -%>
 before_install:
+  - if [ $BUNDLER_VERSION ]; then
+      gem install -v $BUNDLER_VERSION bundler --no-rdoc --no-ri;
+    fi
   - bundle -v
   - rm -f Gemfile.lock
   - gem update --system $RUBYGEMS_VERSION


### PR DESCRIPTION
New version of Bundler does not support ruby versions older than 2.3 or RubyGem versions older than 3.0.0