### PR TITLE
Add options for rspec-puppet coverage reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |mock_with|Defaults to `':mocha'`. Recommended to be set to `':rspec'`, which uses RSpec's built-in mocking library, instead of a third-party one.|
 |spec_overrides|An array of extra lines to add into your `spec_helper.rb`. Can be used as an alternative to `spec_helper_local`|
 |strict_level| Defines the [Puppet Strict configuration parameter](https://puppet.com/docs/puppet/5.4/configuration.html#strict). Defaults to `:warning`. Other values are: `:error` and `:off`. `:error` provides strictest level checking and is encouraged.|
+|coverage_report|Enable [rspec-puppet coverage reports](https://rspec-puppet.com/documentation/coverage/). Defaults to `false`|
+|minimum_code_coverage_percentage|The desired code coverage percentage required for tests to pass. Defaults to `0`|
 
 ## Making local changes to the template
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -601,4 +601,6 @@ spec/default_facts.yml:
   is_pe: false
   macaddress: "AA:AA:AA:AA:AA:AA"
 spec/spec_helper.rb:
+  coverage_report: false
+  minimum_code_coverage_percentage: 0
   strict_level: ":warning"

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -44,6 +44,11 @@ RSpec.configure do |c|
   end
   <%- end -%>
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
+  c.after(:suite) do
+    <%- if @configs['coverage_report'] -%>
+    RSpec::Puppet::Coverage.report!(<%= @configs['minimum_code_coverage_percentage'] %>)
+    <%- end -%>
+  end
 end
 
 def ensure_module_defined(module_name)


### PR DESCRIPTION
Two options are added:
- coverage_report: Defaults to false
- minimum_code_coverage_percentage: Defaults to 0

Wasn't sure how to test this since all the things I could find for using a custom template only allowed pulling from master... 