### PR TITLE
(MAINT) Update JSON pinning to cover Ruby 2.4.5 and future Rubies

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -548,8 +548,11 @@ Gemfile:
         version: '= 1.8.1'
         condition: "Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')"
       - gem: json
-        version: '<= 2.0.4'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.4.4')"
+        version: '= 2.0.4'
+        condition: "Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
+      - gem: json
+        version: '= 2.1.0'
+        condition: "Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
       - gem: 'puppet-module-posix-default-r#{minor_version}'
         platforms: ruby
       - gem: 'puppet-module-posix-dev-r#{minor_version}'


### PR DESCRIPTION
This updates the generated Gemfile to avoid it trying to resolve JSON to 2.1.0 on Ruby 2.4.5 (and future 2.4.x releases of Ruby). It's possible we might have to tweak the ranges if Ruby embeds a different JSON version in a future release but that seems more rare than us just bumping the Ruby patch version.