### PR TITLE
(WIN-251) Add Bolt Filters to template files

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -43,6 +43,7 @@ RSpec.configure do |c|
     Puppet.settings[:strict] = <%= @configs['strict_level'] %>
   end
   <%- end -%>
+  c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
 end
 
 def ensure_module_defined(module_name)


### PR DESCRIPTION
Any module that has unit tests for bolt plans is likely to need these
filters in place. If they are not in the default templates then hand
crafting of these files will have to be done. If it is not, then nothing
can pass Appveyor checks because linting will fail, and any bolt unit
tests will also fail, even though they should have been filtered out and
not run at all.