### PR TITLE
configurable tag_pattern for changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |changelog_user|Sets the github user for the change_log_generator rake task.Optional, if not set it will read the 'author' from the metadata.json file|
 |changelog_project|Sets the github project for the change_log_generator rake task.Optional, if not set it will read the 'name' from the metadata.json file|
 |changelog_since_tag|Sets the github since_tag for the change_log_generator rake task.Required for the changlog rake task|
+|changelog_version_tag_pattern|Template how the version tag is to be generated. Defaults to ```v%s``` which eventually align with tag_pattern property of puppet-blacksmith, thus changelog rake task generated changelog is referring to the correct  |
 |default\_disabled\_lint\_checks| Defines any checks that are to be disabled by default when running lint checks. As default we disable the `--relative` lint check, which compares the module layout relative to the module root. |
 |extra\_disabled\_lint\_checks| Defines any checks that are to be disabled as extras when running lint checks. No defaults are defined for this configuration. |
 |extras|An array of extra lines to add into your Rakefile|

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -99,6 +99,7 @@ appveyor.yml:
   branches:
     - master
 Rakefile:
+  changelog_version_tag_pattern: 'v%s'
   default_disabled_lint_checks:
     - 'relative'
   extras: []

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -43,7 +43,7 @@ end
 
 def changelog_future_release
   return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = JSON.load(File.read('metadata.json'))['version']
+  returnVal = <%= @configs['changelog_version_tag_pattern'].inspect -%> % JSON.load(File.read('metadata.json'))['version']
   raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
   puts "GitHubChangelogGenerator future_release:#{returnVal}"
   returnVal


### PR DESCRIPTION
When using [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator) together with [puppet-blacksmith](https://github.com/voxpupuli/puppet-blacksmith), there is a discrepancy between changelog "future_release" property, which we fill in the version number from metadata.json as is, and the default "tag_pattern" used by puppet-blacksmith to tag the current version, resulting in broken compare links and wrong version tag references in the changelog.

This change introduce the config parameter "changelog_version_tag_pattern" to allow templating the returnVal of changelog_future_release function of Rakefile, and sets the default value to align with blacksmith's "tag_pattern". When using rake tasks ```changelog``` and then ```module:tag``` the changelog will fit to the version tag.