### PR TITLE
Clarify license when using the templates

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -15,3 +15,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+By applying the templates through the PDK (through `pdk new module`,
+`pdk convert`, `pdk update`, or `pdk new ...`) the modifications
+required by section 4 (Redistribution) of the LICENSE are fulfilled.


### PR DESCRIPTION
When using the templates in their intended form through the PDK we do not want to add legal burden on the users. To clarify this, we note here that the rendering of the modules through the PDK already leaves enough traces (e.g. the `template-url` in `metadata.json`) that the conditions of section 4 (Redistribution) are met without any further action on the Licensor's side.

I'll take this opportunity to also point out that the files rendered from the pdk-templates will remain Derivative Works of pdk-templates, e.g. for the purpose of section 3 (Grant of Patent License). Thanks to the specifics of the Apache 2.0 license this clearly does not extend to the main content of  a module, either through "remaining separable" from the templated files, or through the fact that the templated result by itself (e.g. from `pdk new class`) does not pass the hurdle of being a significant work.