### PR TITLE
(PDK-1277) Update gitlab-ci config to test against latest Puppets.

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -585,16 +585,15 @@ Gemfile:
         - 'vendor/bundle'
     bundler_args: '--without system_tests --path vendor/bundle --jobs $(nproc)'
     ruby_versions:
-      '2.1.9':
-        checks:
-          - parallel_spec
-        puppet_version: '~> 4.0'
-        rubygems_version: '2.7.8'
-      '2.4.4':
+      '2.5.1':
         checks:
           - 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'
           - parallel_spec
-        puppet_version: '~> 5.5'
+        puppet_version: '~> 6.0'
+      '2.4.4':
+        checks:
+          - parallel_spec
+        puppet_version: '~> 5.0'
     # beaker: true
 spec/default_facts.yml:
   ipaddress: "172.16.254.254"


### PR DESCRIPTION
Changes to gitlab ci configuration to run static analysis against Puppet 6 and spec test against Puppet 6. Also changes the Puppet 5 job to run against the latest Puppet 5, and removes Puppet 4 from the matrix.