### PR TITLE
(PDK-1297) Allow the use of aliases in default fact files.

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -25,7 +25,7 @@ default_fact_files.each do |f|
   next unless File.exist?(f) && File.readable?(f) && File.size?(f)
 
   begin
-    default_facts.merge!(YAML.safe_load(File.read(f)))
+    default_facts.merge!(YAML.safe_load(File.read(f), [], [], true))
   rescue => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end


### PR DESCRIPTION
When mocking facts, its extremely useful to be able to use aliases in the default fact files:
```yaml
---
ipaddress: &ipaddress '192.168.1.13'
macaddress: &mac '13:13:13:13:13:13'
networking:
  ip: *ipaddress
  mac: *mac
  netmask: &netmask '255.255.255.0'
  network: &network '192.168.1.0'
  primary: 'eth0'
  dhcp: 192.168.1.1
  interfaces:
    'eth0':
      mac: *mac
      mtu: 1500
      ip: *ipaddress
      netmask: *netmask
      network: *network
      bindings:
        - address: *ipaddress
          netmask: *netmask
          network: *network
```