### PR TITLE
ignore .envrc

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -32,6 +32,7 @@
       - '/convert_report.txt'
       - '/update_report.txt'
       - '.DS_Store'
+      - '.envrc'
 .pdkignore:
   required: *ignorepaths
   paths:


### PR DESCRIPTION
This is used by direnv and is a common tool for specifying environment variables for local development.