### PR TITLE
Remove leading whitespace from README template

### DIFF
--- a/moduleroot_init/README.md.erb
+++ b/moduleroot_init/README.md.erb
@@ -1,4 +1,4 @@
-<% name = @configs['module_metadata']['name'].split('-').last rescue '[modulename]' %>
+<%- name = @configs['module_metadata']['name'].split('-').last rescue '[modulename]' -%>
 # <%= name %>
 
 Welcome to your new module. A short overview of the generated parts can be found in the PDK documentation at https://puppet.com/pdk/latest/pdk_generating_modules.html .


### PR DESCRIPTION
When generated, the README.md will have a leading newline.