### PR TITLE
(GH-215) Use the correct ruby version for testing Puppet 5

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -70,7 +70,7 @@
     - env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     - env: CHECK=parallel_spec
     - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.4
+      rvm: 2.4.5
   deploy: true
   user: 'puppet'
   branches:
@@ -575,7 +575,7 @@ Gemfile:
           - 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'
           - parallel_spec
         puppet_version: '~> 6.0'
-      '2.4.4':
+      '2.4.5':
         checks:
           - parallel_spec
         puppet_version: '~> 5.0'


### PR DESCRIPTION
The latest Puppet 5 release is 5.5.10 which uses Ruby 2.4.5.

https://puppet.com/docs/puppet/5.5/about_agent.html