### PR TITLE
(GH-223) .travis.yml does not deploy by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |remove_branches |Allows you to remove default branches set in config_defaults.yml.|
 |notifications   |Allows you to specify the notifications configuration in the .travis.yml file.|
 |remove_notifications   |Allows you to remove default branches set in config_defaults.yml.|
+|user|This string needs to be set to the Puppet Forge user name. To enable deployment the secure key also needs to be set.|
+|secure|This string needs to be set to the encrypted password to enable deployment. See [https://docs.travis-ci.com/user/encryption-keys/#usage](https://docs.travis-ci.com/user/encryption-keys/#usage) for instructions on how to encrypt your password.|
 
 ### .yardopts
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -85,8 +85,6 @@
       stage: spec
     - env: DEPLOY_TO_FORGE=yes
       stage: deploy
-  deploy: true
-  user: 'puppet'
   branches:
     - master
     - /^v\d/

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -114,7 +114,7 @@ notifications:
 <%     end -%>
 <%   end -%>
 <% end -%>
-<% if @configs['deploy'] -%>
+<% unless @configs['user'].nil? || @configs['secure'].nil? -%>
 deploy:
   provider: puppetforge
   user: <%= @configs['user'] %>


### PR DESCRIPTION
Without this patch, the TravisCI configuration will be broken and add a
deployment section with the incorrect password and without documentation
to explain how to do deploys correctly.