### PR TITLE
Revert "Add Visual Studio Code to gitignote (.vscode/)"

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -33,7 +33,6 @@
       - '/update_report.txt'
       - '.DS_Store'
       - '.project'
-      - '.vscode/'
       - '.envrc'
       - '/inventory.yaml'
 .pdkignore:

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -52,6 +52,7 @@
     - '/.travis.yml'
     - '/.yardopts'
     - '/spec/'
+    - '/.vscode/'
 .travis.yml:
   stages:
     - static


### PR DESCRIPTION
This reverts commit 8712ac67a4a4132b4a9473042e4f2da930ca9280.

The `.vscode` directory is used to store workspace level overrides, including testing, formatting etc.  It is _designed_ to be checked into repos and should not be ignored by default.

---

The .vscode directory is not required when packaging a module for the forge.
This commit adds this directory to the list of default PDK ignores.