### PR TITLE
Read the project name from `source` instead of `name`

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -38,7 +38,7 @@ end
 
 def changelog_project
   return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = <%= @configs['changelog_project'].inspect -%> || JSON.load(File.read('metadata.json'))['name']
+  returnVal = <%= @configs['changelog_project'].inspect -%> || JSON.load(File.read('metadata.json'))['source'].match(%r{.*/([^/]*)})[1]
   raise "unable to find the changelog_project in .sync.yml or the name in metadata.json" if returnVal.nil?
   puts "GitHubChangelogGenerator project:#{returnVal}"
   returnVal


### PR DESCRIPTION
It is not safe to presume the module name matches the repo name in GitHub, etc.

Fixes #230