### PR TITLE
Update travis dist to xenial by default

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -1,6 +1,8 @@
 ---
 <% if @configs['dist'] -%>
 dist: <%= @configs['dist'] %>
+<% else -%>
+dist: xenial
 <% end -%>
 language: ruby
 cache: bundler


### PR DESCRIPTION
The xenial dist includes ruby 2.4 and 2.5 by default so users can avoid spending 20-30 seconds, per job, installing these versions of ruby just by changing the dist.