### PR TITLE
(PDK-1351) Enable custom steps in before_script for GitLab CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Gitlab CI uses a .gitlab-ci.yml file in the root of your repository tell Gitlab 
 | custom_jobs    |Define custom Gitlab CI jobs that will be executed. It is recommended that you use this option if you need customized Gitlab CI jobs. Please see the [.gitlab-ci.yml](https://docs.gitlab.com/ce/ci/yaml/README.html) docs for specifics.|
 | rubygems_mirror | Use a custom rubygems mirror url |
 | image          |Define the Docker image to use, when using the Docker runner. Please see the [Using Docker images](https://docs.gitlab.com/ee/ci/docker/using_docker_images.html) docs for specifics.|
+| custom_before_steps |Allows you to pass additional steps to the GitLab CI before_script. Please see the [.gitlab-ci.yml](https://docs.gitlab.com/ce/ci/yaml/#before_script-and-after_script) docs for specifics.|
 
 ### .pdkignore
 

--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -41,6 +41,11 @@ cache:
 <% end -%>
 
 before_script:
+<% if configs['custom_before_steps'] -%>
+<%   configs['custom_before_steps'].each do |step| -%>
+  - <%= step %>
+<%   end -%>
+<% end -%>
   - bundle -v
   - rm Gemfile.lock || true
 <% if configs['rubygems_mirror'] -%>


### PR DESCRIPTION
I have a use case where I need to do additional setup steps for the GitLab pipeline to work (add ca-certificates to allow communication through the proxy). This PR adds the ability to add custom steps in your `.sync.yml` to the before_script in the GitLab CI pipeline.

closes https://github.com/puppetlabs/pdk-templates/issues/134