### PR TITLE
Add documentation to satisfy YARD

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -51,6 +51,8 @@ RSpec.configure do |c|
   end
 end
 
+# Ensures that a module is defined
+# @param module_name Name of the module
 def ensure_module_defined(module_name)
   module_name.split('::').reduce(Object) do |last_module, next_module|
     last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module, false)


### PR DESCRIPTION
My commit hooks complain that the ensure_module_defined method in
spec/spec_helper.rb is undocumented. This commit provides the minimal
documentation strings that satisfies YARD. Better documentation is
always welcome :)