### PR TITLE
(MAINT) Require rubocop-i18n as part of default rubocop config

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -126,7 +126,11 @@ Rakefile:
       Description: People have wide screens, use them.
       Max: 200
 
-    # i18n cops
+    # Disabled i18n cops by default
+    GetText:
+      Enabled: false
+
+    # Configure i18n cops for when they are enabled
     GetText/DecorateString:
       Description: We don't want to decorate test output.
       Exclude:

--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -1,7 +1,10 @@
 <%-
 # note that these hashes need to use rockets, not colons, because rubocop config requires strings as keys
 defaults = {
-  'require' => 'rubocop-rspec',
+  'require' => [
+    'rubocop-rspec',
+    'rubocop-i18n',
+  ],
   'AllCops' => {
     'DisplayCopNames' => true,
     'TargetRubyVersion' => '2.1',


### PR DESCRIPTION
Also disables rubocop-i18n cops by default which is both a sane default and maintains consistency with previous behavior. (They weren't being required before so they weren't running.)

The i18n cops can be enabled on a per-module basis using `.sync.yml`.

Here is the diff of applying this template change to a module:

```diff
--- .rubocop.yml        2019-05-02 11:32:53.282703881 -0700
+++ .rubocop.yml.pdknew 2019-05-02 11:33:06.361388000 -0700
@@ -1,5 +1,7 @@
 ---
-require: rubocop-rspec
+require:
+- rubocop-rspec
+- rubocop-i18n
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: '2.1'
@@ -19,6 +21,8 @@
 Metrics/LineLength:
   Description: People have wide screens, use them.
   Max: 200
+GetText:
+  Enabled: false
 GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
```

Resolves #150 
