### PR TITLE
(MAINT) Add minimum version pinning to default puppet-module-* gem deps

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -567,15 +567,19 @@ Gemfile:
         version: '= 2.1.0'
         condition: "Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
       - gem: 'puppet-module-posix-default-r#{minor_version}'
+        version: '~> 0.3'
         platforms: ruby
       - gem: 'puppet-module-posix-dev-r#{minor_version}'
+        version: '~> 0.3'
         platforms: ruby
       - gem: 'puppet-module-win-default-r#{minor_version}'
+        version: '~> 0.3'
         platforms:
           - mswin
           - mingw
           - x64_mingw
       - gem: 'puppet-module-win-dev-r#{minor_version}'
+        version: '~> 0.3'
         platforms:
           - mswin
           - mingw


### PR DESCRIPTION
Should resolve weird bundler resolution edge-case with Puppet 6.5.0

(Was causing puppet-module-posix-dev to resolve to 0.0.8 in order to satisfy newer `fast_gettext`)