### PR TITLE
(FM-8081) Add DeviceShim template too

### DIFF
--- a/object_templates/transport_device.erb
+++ b/object_templates/transport_device.erb
@@ -1,0 +1,15 @@
+require 'puppet/resource_api/transport/wrapper'
+
+# Initialize the NetworkDevice module if necessary
+module Puppet::Util::NetworkDevice; end
+
+# The <%= name.capitalize %> module only contains the Device class to bridge from puppet's internals to the Transport.
+# All the heavy lifting is done bye the Puppet::ResourceApi::Transport::Wrapper
+module Puppet::Util::NetworkDevice::<%= name.capitalize %> # rubocop:disable Style/ClassAndModuleCamelCase
+  # Bridging from puppet to the <%= name %> transport
+  class Device < Puppet::ResourceApi::Transport::Wrapper
+    def initialize(url_or_config, _options = {})
+      super('<%= name %>', url_or_config)
+    end
+  end
+end

--- a/object_templates/transport_type.erb
+++ b/object_templates/transport_type.erb
@@ -2,7 +2,7 @@ require 'puppet/resource_api'
 
 Puppet::ResourceApi.register_transport(
   name: '<%= name %>',
-  docs: <<-EOS,
+  desc: <<-EOS,
       This transport provides Puppet with the capability to connect to <%= name %> targets.
     EOS
   features: [],


### PR DESCRIPTION
This missing file was an oversight from #251. It is required for a functioning
transport with puppet.