### PR TITLE
Override facterdb with default_facts

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -31,6 +31,11 @@ default_fact_files.each do |f|
   end
 end
 
+# read default_facts and merge them over what is provided by facterdb
+default_facts.each do |fact, value|
+  add_custom_fact fact, value
+end
+
 RSpec.configure do |c|
   c.default_facts = default_facts
   <%- if @configs['hiera_config'] -%>


### PR DESCRIPTION
Prior to this commit, facts provided via default facts would
be ignored if the fact was provided by facterdb.  Which is the
case for any of the standard facts.

After this commit, facts provided via default facts will
override what is provided by facterdb.