### PR TITLE
(maint) Exclude spec folder for GetText/DecorateString

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -134,7 +134,7 @@ Rakefile:
     GetText/DecorateString:
       Description: We don't want to decorate test output.
       Exclude:
-        - 'spec/*'
+        - 'spec/**/*'
 
     # RSpec cops
     RSpec/BeforeAfterAll:


### PR DESCRIPTION
The change ensures that the spec directory along with child directories
are excluded from this rubocop rule.