### PR TITLE
Disable PDK analytics in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ sudo: false
 dist: trusty
 language: generic
 env:
-- PDK=release
-- PDK=nightly
+  - PDK=release PDK_FRONTEND=noninteractive
+  - PDK=nightly PDK_FRONTEND=noninteractive
 before_install:
-- ".travis/install_pdk.sh"
+  - ".travis/install_pdk.sh"
 script:
-- ".travis/test_script.sh"
+  - ".travis/test_script.sh"
 branches:
   only:
-  - master
+    - master
 notifications:
   email: false
   slack:

--- a/.travis/install_pdk.sh
+++ b/.travis/install_pdk.sh
@@ -25,9 +25,6 @@ main() {
     sudo apt-get update -qq
     sudo apt-get install -y pdk
 
-    mkdir -p ~/.config/puppet
-    echo "---\ndisabled: true" > ~/.config/puppet/analytics.yml
-
     /usr/local/bin/pdk --version
 }
 

--- a/.travis/install_pdk.sh
+++ b/.travis/install_pdk.sh
@@ -25,6 +25,9 @@ main() {
     sudo apt-get update -qq
     sudo apt-get install -y pdk
 
+    mkdir -p ~/.config/puppet
+    echo "---\ndisabled: true" > ~/.config/puppet/analytics.yml
+
     /usr/local/bin/pdk --version
 }
 


### PR DESCRIPTION
The recently introduced PDK analytics feature prompts for user
consent on first invocation which is preventing the Travis CI
job from completing successfully on those PDK builds. This
will ensure that PDK analytics are always disabled.