### PR TITLE
(PDK-1417) Allow linter failure on warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |extra\_disabled\_lint\_checks| Defines any checks that are to be disabled as extras when running lint checks. No defaults are defined for this configuration. _Does affect **.puppet-lint.rc**._ |
 |extras|An array of extra lines to add into your Rakefile. As an alternative you can add a directory named `rakelib` to your module and files in that directory that end in `.rake` would be loaded by the Rakefile.|
 |linter\_options| An array of options to be passed into linter config. _Does affect **.puppet-lint.rc**._ |
+|linter\_fail\_on\_warnings| A boolean indicating if the linter should exit non-zero on warnings as well as failures. _Does affect **.puppet-lint.rc**._ |
 
 ### .rubocop.yml
 

--- a/moduleroot/.puppet-lint.rc.erb
+++ b/moduleroot/.puppet-lint.rc.erb
@@ -6,11 +6,16 @@
       rakefile_config['extra_disabled_lint_checks'].to_a,
     ].flatten.uniq
     options = rakefile_config['linter_options'].to_a
+    fail_on_warnings = rakefile_config['linter_fail_on_warnings']
   else
     disabled_checks = []
     options = []
+    fail_on_warnings = false
   end
 -%>
+<% if fail_on_warnings -%>
+--fail-on-warnings
+<% end -%>
 <% disabled_checks.each do |check_name| -%>
 <%- if check_name == 'relative' -%>
 --relative

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -54,6 +54,9 @@ end
 <% checks.each do |check| -%>
 PuppetLint.configuration.send('disable_<%= check %>')
 <% end -%>
+<% if @configs['linter_fail_on_warnings'] -%>
+PuppetLint.configuration.fail_on_warnings = true
+<% end -%>
 <% linter_options =  @configs['linter_options'] || [] -%>
 <% linter_options.each do |option| -%>
 PuppetLint.configuration.send('<%= option %>')


### PR DESCRIPTION
Add 'linter_fail_on_warnings' option to configure puppet lint
to return a failure code for all warnings as well as failure
conditions.