### PR TITLE
travis template extension to enable litmus jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |litmus\_sets     |Allow you to enable travis jobs using [Puppet Litmus](https://github.com/puppetlabs/puppet_litmus/wiki) to conduct acceptance tests.|
 |litmus\_sets['set'] |List name for which images should be provisioned. This must be the `list_name` as defined in your `provision.yaml` placed in the module root directory.|
 |litmus\_sets['collection'] |Name of the Puppet agent to be installed on the litmus targets. Defaults to `puppet6`.|
-|litmus\_sets['commands'] |Array of auxiliary command lines to be applied to all VMs of the set directy after provisioning (before the Puppet agent is installed).|
+|litmus\_sets['commands'] |Array of auxiliary command lines to be applied to all targets of the set directly after provisioning (before the Puppet agent is installed).|
 |docker\_sets     |Allows you to configure sets of docker to run your tests on. For example, if I wanted to run on a docker instance of Ubuntu I would add  `set:docker/ubuntu-14.04` to my docker\_sets attribute.  The docker_sets is a hash that supports the 'set', 'testmode', and 'collection' keys. |
 |docker\_sets['set']| This should refrence the docker nodeset that you wish to run. |
 |docker\_sets['testmode']| This configures the `BEAKER_TESTMODE` to use when testing the docker instance. The two options are `apply` and `agent` if omitted `apply` is used by default. |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |litmus\_sets     |Allow you to enable travis jobs using [Puppet Litmus](https://github.com/puppetlabs/puppet_litmus/wiki) to conduct acceptance tests.|
 |litmus\_sets['set'] |List name for which images should be provisioned. This must be the `list_name` as defined in your `provision.yaml` placed in the module root directory.|
 |litmus\_sets['collection'] |Name of the Puppet agent to be installed on the litmus VMs. Defaults to `puppet6`.|
-|litmus\_sets['commands'] |Array of auxiliary command lines, e.g. `'apt-get install wget -y'` for Debian based VMs, to be applied to all VMs of the set directy after provisioning (before the Puppet agent is installed).|
+|litmus\_sets['commands'] |Array of auxiliary command lines to be applied to all VMs of the set directy after provisioning (before the Puppet agent is installed).|
 |docker\_sets     |Allows you to configure sets of docker to run your tests on. For example, if I wanted to run on a docker instance of Ubuntu I would add  `set:docker/ubuntu-14.04` to my docker\_sets attribute.  The docker_sets is a hash that supports the 'set', 'testmode', and 'collection' keys. |
 |docker\_sets['set']| This should refrence the docker nodeset that you wish to run. |
 |docker\_sets['testmode']| This configures the `BEAKER_TESTMODE` to use when testing the docker instance. The two options are `apply` and `agent` if omitted `apply` is used by default. |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 | bundler\_args   |Define any arguments you want to pass through to bundler. The default is `--without system_tests` which avoids installing unnessesary gems.|
 | env            |Allows you to add new travis job matrix entries based on the included environmnet variables, one per `env` entry; for example, for adding jobs with specific `PUPPET_GEM_VERSION` and/or `CHECK` values.  See the [Travis Environment Variables](https://docs.travis-ci.com/user/environment-variables) documentation for details.|
 | global\_env     |Allows you to set global environment variables which will be defined for all travis jobs; for example, `PARALLEL_TEST_PROCESSORS` or `TIMEOUT`.  See the [Travis Global Environment Variables](https://docs.travis-ci.com/user/environment-variables/#Global-Variables) documentation for details.|
+|litmus\_sets     |Allow you to enable travis jobs using [Puppet Litmus](https://github.com/puppetlabs/puppet_litmus/wiki) to conduct acceptance tests.|
+|litmus\_sets['set'] |List name for which images should be provisioned. This must be the `list_name` as defined in your `provision.yaml` placed in the module root directory.|
+|litmus\_sets['collection'] |Name of the Puppet agent to be installed on the litmus VMs. Defaults to `puppet6`.|
+|litmus\_sets['commands'] |Array of auxiliary command lines, e.g. `'apt-get install wget -y'` for Debian based VMs, to be applied to all VMs of the set directy after provisioning (before the Puppet agent is installed).|
 |docker\_sets     |Allows you to configure sets of docker to run your tests on. For example, if I wanted to run on a docker instance of Ubuntu I would add  `set:docker/ubuntu-14.04` to my docker\_sets attribute.  The docker_sets is a hash that supports the 'set', 'testmode', and 'collection' keys. |
 |docker\_sets['set']| This should refrence the docker nodeset that you wish to run. |
 |docker\_sets['testmode']| This configures the `BEAKER_TESTMODE` to use when testing the docker instance. The two options are `apply` and `agent` if omitted `apply` is used by default. |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 | global\_env     |Allows you to set global environment variables which will be defined for all travis jobs; for example, `PARALLEL_TEST_PROCESSORS` or `TIMEOUT`.  See the [Travis Global Environment Variables](https://docs.travis-ci.com/user/environment-variables/#Global-Variables) documentation for details.|
 |litmus\_sets     |Allow you to enable travis jobs using [Puppet Litmus](https://github.com/puppetlabs/puppet_litmus/wiki) to conduct acceptance tests.|
 |litmus\_sets['set'] |List name for which images should be provisioned. This must be the `list_name` as defined in your `provision.yaml` placed in the module root directory.|
-|litmus\_sets['collection'] |Name of the Puppet agent to be installed on the litmus VMs. Defaults to `puppet6`.|
+|litmus\_sets['collection'] |Name of the Puppet agent to be installed on the litmus targets. Defaults to `puppet6`.|
 |litmus\_sets['commands'] |Array of auxiliary command lines to be applied to all VMs of the set directy after provisioning (before the Puppet agent is installed).|
 |docker\_sets     |Allows you to configure sets of docker to run your tests on. For example, if I wanted to run on a docker instance of Ubuntu I would add  `set:docker/ubuntu-14.04` to my docker\_sets attribute.  The docker_sets is a hash that supports the 'set', 'testmode', and 'collection' keys. |
 |docker\_sets['set']| This should refrence the docker nodeset that you wish to run. |

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -63,6 +63,9 @@
   ruby_versions:
     - 2.5.3
   bundler_args: --without system_tests
+  litmus_sets:
+  litmus_defaults:
+    collection: puppet6
   docker_sets:
   docker_defaults:
     # values will replace @@SET@@ with the docker_sets' value

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -68,6 +68,25 @@ stages:
 matrix:
   fast_finish: true
   include:
+<% (@configs['litmus_sets'] || []).each do |set| -%>
+<%    job = @configs['litmus_defaults'].merge(set || {}) -%>
+    -
+      env: SET=<%= set['set'] %> PUPPET_COLLECTION=<%= job['collection'] %>
+      services: docker
+      sudo: required
+      bundler_args: --with system_tests
+      rvm: 2.5.3
+      stage: acceptance
+      before_script:
+      - bundler exec rake 'litmus:provision_list[<%= set['set'] %>]'
+<%    (job['commands'] || []).each do |cmd| -%>
+      - bundler exec bolt command run '<%= cmd %>' --inventoryfile inventory.yaml --nodes='localhost*'
+<%    end -%>
+      - bundler exec rake 'litmus:install_agent[<%= job['collection'] %>]'
+      - bundler exec rake litmus:install_module
+      script:
+      - bundler exec rake litmus:acceptance:parallel
+<% end -%>
 <% (@configs['docker_sets'] || []).each do |set| -%>
 <%   job = @configs['docker_defaults'].merge(set['options'] || {}) -%>
     -

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -78,14 +78,14 @@ matrix:
       rvm: 2.5.3
       stage: acceptance
       before_script:
-      - bundler exec rake 'litmus:provision_list[<%= set['set'] %>]'
+      - bundle exec rake 'litmus:provision_list[<%= set['set'] %>]'
 <%    (job['commands'] || []).each do |cmd| -%>
-      - bundler exec bolt command run '<%= cmd %>' --inventoryfile inventory.yaml --nodes='localhost*'
+      - bundle exec bolt command run '<%= cmd %>' --inventoryfile inventory.yaml --nodes='localhost*'
 <%    end -%>
-      - bundler exec rake 'litmus:install_agent[<%= job['collection'] %>]'
-      - bundler exec rake litmus:install_module
+      - bundle exec rake 'litmus:install_agent[<%= job['collection'] %>]'
+      - bundle exec rake litmus:install_module
       script:
-      - bundler exec rake litmus:acceptance:parallel
+      - bundle exec rake litmus:acceptance:parallel
 <% end -%>
 <% (@configs['docker_sets'] || []).each do |set| -%>
 <%   job = @configs['docker_defaults'].merge(set['options'] || {}) -%>

--- a/moduleroot/spec/spec_helper_acceptance.rb.erb
+++ b/moduleroot/spec/spec_helper_acceptance.rb.erb
@@ -1,0 +1,57 @@
+require 'serverspec'
+require 'puppet_litmus'
+require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
+include PuppetLitmus
+
+if ENV['TARGET_HOST'].nil? || ENV['TARGET_HOST'] == 'localhost'
+  puts 'Running tests against this machine !'
+  if Gem.win_platform?
+    set :backend, :cmd
+  else
+    set :backend, :exec
+  end
+else
+  # load inventory
+  inventory_hash = inventory_hash_from_inventory_file
+  node_config = config_from_node(inventory_hash, ENV['TARGET_HOST'])
+
+  if target_in_group(inventory_hash, ENV['TARGET_HOST'], 'docker_nodes')
+    host = ENV['TARGET_HOST']
+    set :backend, :docker
+    set :docker_container, host
+  elsif target_in_group(inventory_hash, ENV['TARGET_HOST'], 'ssh_nodes')
+    set :backend, :ssh
+    options = Net::SSH::Config.for(host)
+    options[:user] = node_config.dig('ssh', 'user') unless node_config.dig('ssh', 'user').nil?
+    options[:port] = node_config.dig('ssh', 'port') unless node_config.dig('ssh', 'port').nil?
+    options[:keys] = node_config.dig('ssh', 'private-key') unless node_config.dig('ssh', 'private-key').nil?
+    options[:password] = node_config.dig('ssh', 'password') unless node_config.dig('ssh', 'password').nil?
+    options[:verify_host_key] = Net::SSH::Verifiers::Null.new unless node_config.dig('ssh', 'host-key-check').nil?
+    host = if ENV['TARGET_HOST'].include?(':')
+             ENV['TARGET_HOST'].split(':').first
+           else
+             ENV['TARGET_HOST']
+           end
+    set :host,        options[:host_name] || host
+    set :ssh_options, options
+    set :request_pty, true
+  elsif target_in_group(inventory_hash, ENV['TARGET_HOST'], 'winrm_nodes')
+    require 'winrm'
+
+    set :backend, :winrm
+    set :os, family: 'windows'
+    user = node_config.dig('winrm', 'user') unless node_config.dig('winrm', 'user').nil?
+    pass = node_config.dig('winrm', 'password') unless node_config.dig('winrm', 'password').nil?
+    endpoint = "http://#{ENV['TARGET_HOST']}:5985/wsman"
+
+    opts = {
+      user: user,
+      password: pass,
+      endpoint: endpoint,
+      operation_timeout: 300,
+    }
+
+    winrm = WinRM::Connection.new opts
+    Specinfra.configuration.winrm = winrm
+  end
+end

--- a/moduleroot_init/.fixtures.yml.erb
+++ b/moduleroot_init/.fixtures.yml.erb
@@ -4,3 +4,8 @@
 fixtures:
   forge_modules:
 #     stdlib: "puppetlabs/stdlib"
+## uncomment the following lines when enabling litmus acceptance testing
+#  repositories:
+#    facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
+#    puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+#    provision: 'git://github.com/puppetlabs/provision.git'


### PR DESCRIPTION
This will enable pdk controlled modules an easy setup of travis-ci jobs using litmus for acceptance testing. The setup through `.sync.yml`, involving `litmus_sets` key, is similar to that which leads to beaker jobs, and end up with jobs  just like those found in the example puppetlabs/motd module.

This is a pure feature extension, thus non of the current use-cases of pdk will be affected.