### PR TITLE
test against puppet versions of latest PE, latest PE LTS and latest gem

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -80,7 +80,7 @@
     - env: PUPPET_GEM_VERSION="5.5.14" CHECK=parallel_spec
       rvm: 2.4.5
       stage: spec
-    - env: PUPPET_GEM_VERSION="6.0.9" CHECK=parallel_spec
+    - env: PUPPET_GEM_VERSION="6.4.2" CHECK=parallel_spec
       rvm: 2.5.3
       stage: spec
     - env: PUPPET_GEM_VERSION="~> 6" CHECK=parallel_spec

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -77,10 +77,13 @@
   includes:
     - env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
       stage: static
-    - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
+    - env: PUPPET_GEM_VERSION="5.5.14" CHECK=parallel_spec
       rvm: 2.4.5
       stage: spec
-    - env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
+    - env: PUPPET_GEM_VERSION="6.0.9" CHECK=parallel_spec
+      rvm: 2.5.3
+      stage: spec
+    - env: PUPPET_GEM_VERSION="~> 6" CHECK=parallel_spec
       rvm: 2.5.3
       stage: spec
     - env: DEPLOY_TO_FORGE=yes


### PR DESCRIPTION
Pinning the Puppet versions for spec tests to run tests against:
* latest LTS PE version
* latest PE version
* latest gem version

Versions as of todays [Component versions in recent PE releases](https://puppet.com/docs/pe/2019.0/component_versions_in_recent_pe_releases.html#puppet-enterprise-agent-and-server-components).