### PR TITLE
(MODULES-9749) Update changelog instructions

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -96,11 +96,16 @@ else
   task :changelog do
     raise <<EOM
 The changelog tasks depends on unreleased features of the github_changelog_generator gem.
-Please manually add it to your .sync.yml for now, and run `pdk update`:
+If you installed your gems without release_prep, you will want to ensure you bundle install
+without skipping that gem group.
+
+If you did not specify without release_prep during your bundle install, it is possible your
+gemfile does not include the gem. Please manually add it to your .sync.yml for now, and run 
+`pdk update`:
 ---
 Gemfile:
   optional:
-    ':development':
+    ':release_prep':
       - gem: 'github_changelog_generator'
         git: 'https://github.com/skywinder/github-changelog-generator'
         ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'


### PR DESCRIPTION
Prior to this commit if the gem for github_changelog_generator could
not be found the error message raised by the changelog rake task
advised the reader to add the changelog generator to the .sync.yaml
in the development gem group.

This commit updates that advice to clarify that the gem may not be
installed intentionally and, if not, to ensure it exists in the gem
file by using .sync.yaml to add it to the release_prep gem group
and running a pdk update.