### PR TITLE
Adds helper methods for facterdb

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -31,6 +31,38 @@ default_fact_files.each do |f|
   end
 end
 
+# @return [String] - the path to the fixtures directory
+def fixtures_dir
+  @fixtures_dir ||= File.join(__dir__, 'fixtures')
+end
+
+# @return [String] = the path the directory of external facterdb facts
+# Most users will likely not have a custom facterdb_facts git repo defined
+# but if they do then can add it to the fixtures file and name it facterdb_facts.
+# See https://github.com/camptocamp/facterdb#supplying-custom-external-facts
+def mock_facts
+  @mock_facts ||= File.join(fixtures_dir, 'facterdb_facts')
+end
+
+# @return [Hash] - returns a hash of testable operating systems
+# uncomment and replace empty hash
+# modify to your liking, default to all supported
+# operating systems defined in the metadata.json file
+# sometimes you don't want to test on 20 operating systems, this controls that
+def test_on
+  @test_on ||= {}
+  # {hardwaremodels: ['x86_64'],
+  # supported_os: [
+  #     {
+  #         'operatingsystem' => 'Ubuntu',
+  #         'operatingsystemrelease' => ['14.04'],
+  #     },
+  # ]},
+end
+
+# set the mock facts dir for facterdb 
+ENV['FACTERDB_SEARCH_PATHS'] = mock_facts
+
 # read default_facts and merge them over what is provided by facterdb
 default_facts.each do |fact, value|
   add_custom_fact fact, value


### PR DESCRIPTION
Without this change a user doesn't have an easy way to specify 
where their external facterdb facts are.   If you are unfamiliar with external facts
please see the following documentation. 

https://github.com/camptocamp/facterdb#supplying-custom-external-facts

Additionally, this change adds a helper method to toggle the supported operating systems.
This can be handy when testing because sometimes we don't want to see the same test fail
for every supported operating system in the metadata.json. The test_on method allows the user to control which systems are supported without changing the metadata.  This method would be used like so:

```
# spec_helper
def test_on
  @test_on ||= 
   {hardwaremodels: ['x86_64'],
   supported_os: [
       {
           'operatingsystem' => 'Ubuntu',
           'operatingsystemrelease' => ['14.04'],
       },
   ]}
end

# spec/classes/some_class_spec.rb
on_supported_os(test_on).each do |os, os_facts|
    context "on #{os}" do
      it {is_expected.to compile }
    end
end
```

Usage of this method is optional for the user.  