### PR TITLE
(maint) Add default ipaddress6 fact

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -609,6 +609,7 @@ Gemfile:
     # beaker: true
 spec/default_facts.yml:
   ipaddress: "172.16.254.254"
+  ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
   is_pe: false
   macaddress: "AA:AA:AA:AA:AA:AA"
 spec/spec_helper.rb:

--- a/moduleroot/spec/default_facts.yml.erb
+++ b/moduleroot/spec/default_facts.yml.erb
@@ -3,6 +3,7 @@
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
 ipaddress: "<%= @configs['ipaddress'] %>"
+ipaddress6: "<%= @configs['ipaddress6'] %>"
 is_pe: <%= @configs['is_pe'] %>
 macaddress: "<%= @configs['macaddress'] %>"
 <% if !@configs['extra_facts'].nil? -%>


### PR DESCRIPTION
Puppet 6.9.0 now sets a serverip6 fact which is set to the ipaddress6
fact value on the compiling host.

https://github.com/puppetlabs/puppet/commit/48f720a68d9a2903b9ea71561f87af16136d76f6