### PR TITLE
Update the TargetRubyVersion to match the default PDK version

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -7,7 +7,7 @@ defaults = {
   ],
   'AllCops' => {
     'DisplayCopNames' => true,
-    'TargetRubyVersion' => '2.1',
+    'TargetRubyVersion' => '2.5',
     'Include' => [
       './**/*.rb',
     ],


### PR DESCRIPTION
Validation can fail when using `a: b` format for hashes in rspec tests with `TargetRubyVersion` set to 2.1. Puppet is using at least Ruby version 2.5 these days, the default should be updated.