### PR TITLE
(PDK-1439) Ignore GetText rubocop rules for the off profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,6 @@
 /tmp/
 /vendor/
 /convert_report.txt
-
+# Rubocop profile builder temporary files
+/rubocop/.rubocop.yml
+/rubocop/.rubocop_todo.yml

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'rubocop', '= 0.49.1'
 gem 'rubocop-rspec', '= 1.15.1'
+gem 'rubocop-i18n', '= 1.2.0'

--- a/rubocop/defaults-0.49.1.yml
+++ b/rubocop/defaults-0.49.1.yml
@@ -2,6 +2,10 @@
 :default_enabled_cops:
 - Bundler/DuplicatedGem
 - Bundler/OrderedGems
+- GetText/DecorateFunctionMessage
+- GetText/DecorateString
+- GetText/DecorateStringFormattingUsingInterpolation
+- GetText/DecorateStringFormattingUsingPercent
 - Layout/AccessModifierIndentation
 - Layout/AlignArray
 - Layout/AlignHash

--- a/rubocop/profile_builder.rb
+++ b/rubocop/profile_builder.rb
@@ -1,19 +1,22 @@
 #!/usr/bin/env ruby
 
+this_dir = __dir__
+raise "This script must be run from the #{this_dir} directory" if this_dir != Dir.pwd
+
 require 'yaml'
 require 'rubocop/version'
 
 File.delete('.rubocop.yml') if File.exist?('.rubocop.yml')
 
-default_configs = YAML.load(`rubocop --show-cops --require rubocop-rspec`)
+default_configs = YAML.load(`rubocop --show-cops --require rubocop-rspec --require rubocop-i18n`)
 all_cops = default_configs.keys - [ 'AllCops', 'require' ]
 default_enabled_cops = all_cops.find_all { |c| default_configs[c]['Enabled'] }
 default_disabled_cops = all_cops - default_enabled_cops
 
 $stderr.puts "Found #{default_enabled_cops.length} enabled, and #{default_disabled_cops.length} disabled cops in the default config."
 
-# fetch config from current PDK
-FileUtils.cp("../../pdk/.rubocop.yml", '.')
+# fetch config from current PDK.  Assume it's in the same directory as this repo.
+FileUtils.cp(File.join('..', '..', 'pdk', '.rubocop.yml'), '.')
 # stub out the included config to avoid rubocop complaints
 File.open('.rubocop_todo.yml', 'w') do |f|
   # nothing
@@ -21,7 +24,7 @@ end
 config = YAML.load(File.read('.rubocop.yml'))
 
 configured_cops = YAML.load(`rubocop --show-cops`)
-config_enabled_cops = all_cops.find_all { |c| configured_cops[c]['Enabled'] }
+config_enabled_cops = all_cops.find_all { |c| configured_cops[c] && configured_cops[c]['Enabled'] }
 config_disabled_cops = all_cops - config_enabled_cops
 
 $stderr.puts "Found #{config_enabled_cops.length} enabled, and #{config_disabled_cops.length} disabled cops in the recommended config."
@@ -48,7 +51,7 @@ force_disabled_cops = config_disabled_cops - default_disabled_cops
 #     end
 #   end
 # end
-File.open("defaults-#{RuboCop::Version.version}.yml", 'w') do |f|
+File.open("defaults-#{RuboCop::Version.version}.yml", 'wb') do |f|
   f.puts YAML.dump(default_enabled_cops: default_enabled_cops)
 end
 


### PR DESCRIPTION
Previously the rubocop profile builder had not been updated for the i18n rubocop
rules.  This commit:
* Updates the script to work on Windows
* Updates the script for running in the `/rubocop/` directory
* Adds the i18n rubocop gem in the Gemfile so it can be profiled
* Updates the 0.49.1 rubocop profile with the GetText/* rules