### PR TITLE
(maint) Add a default CODEOWNERS to new module init.

### DIFF
--- a/moduleroot_init/CODEOWNERS.erb
+++ b/moduleroot_init/CODEOWNERS.erb
@@ -1,0 +1,10 @@
+# You can use a CODEOWNERS file to define individuals or teams that are
+# responsible for code in a repository.
+
+# To learn more about CODEOWNERS, please refer to:
+# https://help.github.com/en/articles/about-code-owners
+
+# Uncomment the line below and add your GitHub Username to start using
+# CODEOWNERS feature.
+
+#* @github_username


### PR DESCRIPTION
Adds a CODEOWNERS file to the inital module skeleton generation. This feature
is used internally and is a feature we should promote to facilitate
maintenance.