### PR TITLE
Ignore *~ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*.sw[op]
+*~
 .metadata
 .yardoc
 .yardwarns


### PR DESCRIPTION
~ is a common suffix for editor temporary or editor backup files, for editors that aren't vim.