### PR TITLE
(#283) Unwrap password in transport object template

### DIFF
--- a/object_templates/transport.erb
+++ b/object_templates/transport.erb
@@ -16,7 +16,7 @@ module Puppet::Transport
       context.debug("Checking connection to #{@connection_info[:host]}:#{@connection_info[:port]}")
       # in a real world implementation, the password would be checked by connecting
       # to the target device or checking that an existing connection is still alive
-      raise 'authentication error' if @connection_info[:password] == 'invalid'
+      raise 'authentication error' if @connection_info[:password].unwrap == 'invalid'
     end
 
     # Retrieve facts from the target and return in a hash

--- a/object_templates/transport_spec.erb
+++ b/object_templates/transport_spec.erb
@@ -6,11 +6,12 @@ RSpec.describe Puppet::Transport::<%= transport_class %> do
   subject(:transport) { described_class.new(context, connection_info) }
 
   let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+  let(:password) { 'aih6cu6ohvohpahN' }
   let(:connection_info) do
     {
       host: 'api.example.com',
       user: 'admin',
-      password: 'aih6cu6ohvohpahN',
+      password: Puppet::Pops::Types::PSensitiveType::Sensitive.new(password),
     }
   end
 
@@ -30,7 +31,7 @@ RSpec.describe Puppet::Transport::<%= transport_class %> do
     end
 
     context 'with invalid credentials' do
-      let(:connection_info) { super().merge(password: 'invalid') }
+      let(:password) { 'invalid' }
 
       it 'raises an error' do
         expect { transport.verify(context) }.to raise_error RuntimeError, %r{authentication error}


### PR DESCRIPTION
Unwraps the password value in the transport template when used. Also updated the specs for the transport to mock the password with `Sensitive` data type objects.

```
$ pdk test unit --verbose
pdk (INFO): Using Ruby 2.4.7
pdk (INFO): Using Puppet 6.10.1
[✔] Preparing to run the unit tests.
/home/tsharpe/.rbenv/versions/2.4.7/bin/ruby -I/home/tsharpe/.pdk/cache/ruby/2.4.0/gems/rspec-core-3.9.0/lib:/home/tsharpe/.pdk/cache/ruby/2.4.0/gems/rspec-support-3.9.0/lib /home/tsharpe/.pdk/cache/ruby/2.4.0/gems/rspec-core-3.9.0/exe/rspec --pattern spec/\{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit\}/\*\*/\*_spec.rb --format documentation
Run options: exclude {:bolt=>true}

Puppet::Transport::Bar
  initialize(context, connection_info)
    is expected not to raise Exception
  verify(context)
    with valid credentials
      returns
    with invalid credentials
      raises an error
  facts(context)
    returns basic facts
  close(context)
    releases resources
```

Fixes #283