### PR TITLE
(PDK-1500) Update Appveyor and Gemfile templates for Litmus

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |matrix|This defines the matrix of jobs to be executed at runtime. Each defines environment variables for that specific job run. In our defaults we have a Ruby version specfied, followed by the check that will be run for that job.|
 |simplecov|Set to `true` to enable collecting ruby code coverage.|
 |test\_script|This defines the test script that will be executed. For our purposes the default is set to `bundle exec rake %CHECK%`. As appveyor iterates through the test matrix as we defined above, it resolves the variable CHECK and runs the resulting command. For example, our last test script would be executed as `bundle exec rake spec`, which would run the spec tests of the module.|
+|use_litmus|Configures Appveyor to be able to use Litmus for acceptance testing jobs|
 
 ### Rakefile
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 | :------------- |:--------------|
 |required|Allows you to specify gems that are required within the Gemfile. Gems can be defined here within groups, for example we use the :development gem group to add in several gems that are relevant to the development of any module and the :system_tests gem group for gems relevant only to acceptance testing.|
 |optional|Allows you to specify additional gems that are required within the Gemfile. This key can be used to further configure the Gemfile through assignment of a value in the .sync.yml file.|
+|use_litmus|Configures development gems to include Litmus for acceptance testing.|
 
 >Within each Gem group defined using the options above one or more gem item definitions may be listed in an array. Each item in that array must be a gem item hash.
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -94,6 +94,7 @@
   markup: markdown
 appveyor.yml:
   appveyor_bundle_install: "bundle install --jobs 4 --retry 2 --without system_tests"
+  use_litmus: false
   matrix:
     - RUBY_VERSION: 24-x64
       CHECK: "syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -545,6 +545,7 @@ Rakefile:
       configs: *default_configs
       enabled_cops: all
 Gemfile:
+  use_litmus: false
   required:
     ':development':
       - gem: fast_gettext

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -39,6 +39,26 @@ def gem_spec(gem, max_len)
 
   output
 end
+
+# Munge the default settings, if the `use_litmus` setting is asserted
+if @configs['use_litmus']
+  # Find the development metagems and change the version restriction to be at
+  # least 0.4. This is the minimum version where Litmus was introduced.
+  # We know that it should be in the `required` and the `development` group
+  dev_gems = []
+  if @configs['required'] && @configs['required'][':development']
+    @configs['required'][':development'].each do |gem|
+      next unless [
+          'puppet-module-posix-dev-r#{minor_version}',
+          'puppet-module-win-dev-r#{minor_version}'
+        ].include?(gem['gem'])
+      # Change the version of the development gems to ones that include the
+      # litmus gem. Note that this is mostly a noop on older rubies (<= 2.3)
+      # which won't have litmus in there.
+      gem['version'] = '~> 0.4' if gem['version'] = '~> 0.3'
+    end
+  end
+end
 -%>
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 

--- a/moduleroot/appveyor.yml.erb
+++ b/moduleroot/appveyor.yml.erb
@@ -40,6 +40,20 @@ environment:
     <%- end -%>
   <%- end -%>
 <%- end -%>
+<% if @configs['use_litmus'] -%>
+for:
+-
+  matrix:
+    only:
+      - ACCEPTANCE: yes
+  install:
+    - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+    - bundle install --jobs 4 --retry 2
+    - type Gemfile.lock
+  test_script:
+     - bundle exec rake spec_prep
+     - bundle exec rake litmus:acceptance:localhost
+<% end -%>
 matrix:
   fast_finish: true
 install:


### PR DESCRIPTION
Previously if a module wanted to use Litmus for acceptance testing it could not
be managed by PDK.  This commit adds the requried boiler plate to the appveyor
configuration file, which then allows Litmus based tasks to be executed.

---

Previously if a module used Litmus for acceptance testing it was possible that
Bundler would choose Development metagems that did not include Litmus which
would then cause CI, or local testing failures.  This commit:

* Adds a `use_litmus` setting to the Gemfile
* When the use_litmus setting is set to true, the Gemfile template is modified
  so that the development gems will be select a version that contains the
  litmus gem

Note that this munging is used because it is not possible to add the complex
logic into the config_defaults file. Nor is it possible to configure this using
knockout prefix in a module's sync.yml.