### PR TITLE
(maint) Make module deployment in Travis opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |remove_branches |Allows you to remove default branches set in config_defaults.yml.|
 |notifications   |Allows you to specify the notifications configuration in the .travis.yml file.|
 |remove_notifications   |Allows you to remove default branches set in config_defaults.yml.|
+|deploy_to_forge|Allows you to change the automatic deployment of modules to the forge. Sub keys are `enabled` and `tag_regex` which are detailed below|
+|deploy_to_forge\\**enabled**|Allows you to enable or disable automatic forge deployments. Default is true|
+|deploy_to_forge\\**tag_regex**|Allows you to use a regular expression to define which tags will trigger a deployment.  The default is `^v\d`|
 |before_deploy|An array which can allow a user to specify the commands to run before kicking off a deployment. See [https://docs.travis-ci.com/user/deployment/releases/#setting-the-tag-at-deployment-time].|
 |user|This string needs to be set to the Puppet Forge user name. To enable deployment the secure key also needs to be set.|
 |secure|This string needs to be set to the encrypted password to enable deployment. See [https://docs.travis-ci.com/user/encryption-keys/#usage](https://docs.travis-ci.com/user/encryption-keys/#usage) for instructions on how to encrypt your password.|

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -58,8 +58,6 @@
     - static
     - spec
     - acceptance
-    - name: deploy
-      if: tag =~ ^v\d
   ruby_versions:
     - 2.5.3
   bundler_args: --without system_tests
@@ -83,13 +81,14 @@
     - env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
       rvm: 2.5.3
       stage: spec
-    - env: DEPLOY_TO_FORGE=yes
-      stage: deploy
   branches:
     - master
     - /^v\d/
   notifications:
     email: false
+  deploy_to_forge:
+    enabled: true
+    tag_regex: "^v\\d"
 .yardopts:
   markup: markdown
 appveyor.yml:

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -1,3 +1,18 @@
+<%
+  if @configs['deploy_to_forge']['enabled']
+    # If Deploy To Forge is enabled..
+    # - Inject the deployment stage using the tag regex
+    @configs['stages'] << {
+      'name' => 'deploy',
+      'if'   => "tag =~ #{@configs['deploy_to_forge']['tag_regex']}"
+    }
+    # - Inject the deployment task into the includes
+    @configs['includes'] << {
+      'env'   => 'DEPLOY_TO_FORGE=yes',
+      'stage' => 'deploy'
+    }
+  end
+-%>
 ---
 <% if @configs['dist'] -%>
 dist: <%= @configs['dist'] %>


### PR DESCRIPTION
Previously the Travis configuration was setup in a way that made it difficult
to stop auto-forge deployment or use a different tagging system.  This commit
makes the auto deployment of modules optional (opt-out), and allow users to
configure their own tag regex if needed.

This commit preserves the current template defaults, thereby making this a non
breaking change.