### PR TITLE
Update puppet-module gems to current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 | :------------- |:--------------|
 |required|Allows you to specify gems that are required within the Gemfile. Gems can be defined here within groups, for example we use the :development gem group to add in several gems that are relevant to the development of any module and the :system_tests gem group for gems relevant only to acceptance testing.|
 |optional|Allows you to specify additional gems that are required within the Gemfile. This key can be used to further configure the Gemfile through assignment of a value in the .sync.yml file.|
-|use_litmus|Configures development gems to include Litmus for acceptance testing.|
 
 >Within each Gem group defined using the options above one or more gem item definitions may be listed in an array. Each item in that array must be a gem item hash.
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -544,7 +544,6 @@ Rakefile:
       configs: *default_configs
       enabled_cops: all
 Gemfile:
-  use_litmus: false
   required:
     ':development':
       - gem: fast_gettext
@@ -574,19 +573,19 @@ Gemfile:
           - mingw
           - x64_mingw
       - gem: 'puppet-module-posix-default-r#{minor_version}'
-        version: '~> 0.3'
+        version: '~> 0.4'
         platforms: ruby
       - gem: 'puppet-module-posix-dev-r#{minor_version}'
-        version: '~> 0.3'
+        version: '~> 0.4'
         platforms: ruby
       - gem: 'puppet-module-win-default-r#{minor_version}'
-        version: '~> 0.3'
+        version: '~> 0.4'
         platforms:
           - mswin
           - mingw
           - x64_mingw
       - gem: 'puppet-module-win-dev-r#{minor_version}'
-        version: '~> 0.3'
+        version: '~> 0.4'
         platforms:
           - mswin
           - mingw

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -39,26 +39,6 @@ def gem_spec(gem, max_len)
 
   output
 end
-
-# Munge the default settings, if the `use_litmus` setting is asserted
-if @configs['use_litmus']
-  # Find the development metagems and change the version restriction to be at
-  # least 0.4. This is the minimum version where Litmus was introduced.
-  # We know that it should be in the `required` and the `development` group
-  dev_gems = []
-  if @configs['required'] && @configs['required'][':development']
-    @configs['required'][':development'].each do |gem|
-      next unless [
-          'puppet-module-posix-dev-r#{minor_version}',
-          'puppet-module-win-dev-r#{minor_version}'
-        ].include?(gem['gem'])
-      # Change the version of the development gems to ones that include the
-      # litmus gem. Note that this is mostly a noop on older rubies (<= 2.3)
-      # which won't have litmus in there.
-      gem['version'] = '~> 0.4' if gem['version'] = '~> 0.3'
-    end
-  end
-end
 -%>
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 


### PR DESCRIPTION
The 0.4 series has been in use in the Content team for a while now and
has proven to be stable.