### PR TITLE
FM-8769 - add use_litmus to configure to use Litmus for acceptance testing jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,12 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |deploy_to_forge\\**enabled**|Allows you to enable or disable automatic forge deployments. Default is true|
 |deploy_to_forge\\**tag_regex**|Allows you to use a regular expression to define which tags will trigger a deployment.  The default is `^v\d`|
 |before_deploy|An array which can allow a user to specify the commands to run before kicking off a deployment. See [https://docs.travis-ci.com/user/deployment/releases/#setting-the-tag-at-deployment-time].|
-|use_litmus| By default it is disabled. Set to `true` to configure travis to use Litmus testing tool for acceptance testing jobs with default values. Its sub keys are `provision_list`, `puppet_collection`, `rvm`, `install_wget` which are detailed below.|.|
-|use_litmus\\**puppet_collection**|Allows you to specify the puppet version under test as an array. Default test are ran on _puppet 5_ and _puppet 6_|
-|use_litmus\\**provision_list**|Allows you to specify the platforms list under test as an array. Default test are ran on platformes defined in provision.yaml file under _travis_deb_ and _travis_el_|
-|use_litmus\\**rvm**|Allows you to specify the ruby version under test. Default is set to _2.5.3_|
-|use_litmus\\**install_wget**|Allows you to enable automatic installation of wget on the platform under test. We need this when installing agent on travis_deb platforms|
+|use_litmus| By default it is disabled. Set to `true` to configure travis to use Litmus testing tool for acceptance testing jobs with default values.|
+|litmus|Allows you to update default config values. Its sub keys are `provision_list`, `puppet_collection`, `rvm`, `install_wget` which are detailed below.|
+|litmus\\**puppet_collection**|Allows you to specify the puppet version under test. Default test are ran on _puppet 5_ and _puppet 6_.|
+|litmus\\**provision_list**|Allows you to specify the platforms list under test. Default test are ran on platformes defined in provision.yaml file under _travis_deb_ and _travis_el_|
+|litmus\\**rvm**|Allows you to specify the ruby version under test. Default it is set to _2.5.3_|
+|litmus\\**install_wget**|Allows you to enable automatic installation of wget on the platform under test. We need this when installing agent on travis_deb platforms. Default it is disabled. |
 |user|This string needs to be set to the Puppet Forge user name. To enable deployment the secure key also needs to be set.|
 |secure|This string needs to be set to the encrypted password to enable deployment. See [https://docs.travis-ci.com/user/encryption-keys/#usage](https://docs.travis-ci.com/user/encryption-keys/#usage) for instructions on how to encrypt your password.|
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |deploy_to_forge\\**enabled**|Allows you to enable or disable automatic forge deployments. Default is true|
 |deploy_to_forge\\**tag_regex**|Allows you to use a regular expression to define which tags will trigger a deployment.  The default is `^v\d`|
 |before_deploy|An array which can allow a user to specify the commands to run before kicking off a deployment. See [https://docs.travis-ci.com/user/deployment/releases/#setting-the-tag-at-deployment-time].|
+|use_litmus| By default it is disabled. Set to `true` to configure travis to use Litmus testing tool for acceptance testing jobs with default values. Its sub keys are `provision_list`, `puppet_collection`, `rvm`, `install_wget` which are detailed below.|.|
+|use_litmus\\**puppet_collection**|Allows you to specify the puppet version under test as an array. Default test are ran on _puppet 5_ and _puppet 6_|
+|use_litmus\\**provision_list**|Allows you to specify the platforms list under test as an array. Default test are ran on platformes defined in provision.yaml file under _travis_deb_ and _travis_el_|
+|use_litmus\\**rvm**|Allows you to specify the ruby version under test. Default is set to _2.5.3_|
+|use_litmus\\**install_wget**|Allows you to enable automatic installation of wget on the platform under test. We need this when installing agent on travis_deb platforms|
 |user|This string needs to be set to the Puppet Forge user name. To enable deployment the secure key also needs to be set.|
 |secure|This string needs to be set to the encrypted password to enable deployment. See [https://docs.travis-ci.com/user/encryption-keys/#usage](https://docs.travis-ci.com/user/encryption-keys/#usage) for instructions on how to encrypt your password.|
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -85,6 +85,11 @@
     - master
     - /^v\d/
   use_litmus: false
+  litmus:
+    provision_list: [travis_deb, travis_el]
+    puppet_collection: [puppet5, puppet6]
+    rvm: '2.5.3'
+    install_wget: no
   notifications:
     email: false
   deploy_to_forge:

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -84,6 +84,7 @@
   branches:
     - master
     - /^v\d/
+  use_litmus: false
   notifications:
     email: false
   deploy_to_forge:

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -109,11 +109,38 @@ matrix:
       <%= key %>: <%= job[key].gsub(/@@SET@@/, set['set']).gsub(/@@COLLECTION@@/, set.fetch('collection', 'puppet6')).gsub(/@@TESTMODE@@/, set.fetch('testmode', 'apply')) %>
 <%   end -%>
 <% end -%>
+<% if @configs['use_litmus'] == true
+  @configs.delete('use_litmus')
+  @configs.merge!('use_litmus'=> {})
+end
+if @configs['use_litmus']
+  @configs['use_litmus']['puppet_collection'] ||= ['puppet5', 'puppet6']
+  @configs['use_litmus']['provision_list'] ||= ['travis_el','travis_deb']
+  @configs['use_litmus']['rvm'] ||= '2.5.3'
+  @configs['use_litmus']['puppet_collection'].each do |puppet_version|
+  @configs['use_litmus']['provision_list'].each do |platform|-%>
+    -
+<%  if @configs['use_litmus']['install_wget']-%>
+      before_script: ["bundle exec rake 'litmus:provision_list[<%=platform%>]'", "bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'", "bundle exec rake 'litmus:install_agent[<%=puppet_version%>]'", "bundle exec rake litmus:install_module"]
+<%  else-%>
+      before_script: ["bundle exec rake 'litmus:provision_list[<%=platform%>]'", "bundle exec rake 'litmus:install_agent[<%=puppet_version%>]'", "bundle exec rake litmus:install_module"]
+<%  end-%>
+      bundler_args: 
+      dist: trusty
+      env: PLATFORMS=<%=platform%>_<%=puppet_version%>
+      rvm: <%=@configs['use_litmus']['rvm']%>
+      script: ["bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+      sudo: required
+<%   end -%>
+<%  end -%>
+<% end -%>
 <% (@configs['includes'] - (@configs['remove_includes'] || []) + (@configs['extras'] || [])).each do |job| -%>
     -
 <%   job.keys.sort.each do |key| -%>
       <%= key %>: <%= job[key] %>
-<%   end -%>
+<%  end -%>
 <% end -%>
 <% if @configs['allow_failures'] -%>
   allow_failures:

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -113,11 +113,13 @@ matrix:
   @configs['litmus']['puppet_collection'].each do |puppet_version|
   @configs['litmus']['provision_list'].each do |platform|-%>
     -
+      before_script:
+      - "bundle exec rake 'litmus:provision_list[<%=platform%>]'"
 <%  if @configs['litmus']['install_wget']-%>
-      before_script: ["bundle exec rake 'litmus:provision_list[<%=platform%>]'", "bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'", "bundle exec rake 'litmus:install_agent[<%=puppet_version%>]'", "bundle exec rake litmus:install_module"]
-<%  else-%>
-      before_script: ["bundle exec rake 'litmus:provision_list[<%=platform%>]'", "bundle exec rake 'litmus:install_agent[<%=puppet_version%>]'", "bundle exec rake litmus:install_module"]
+      - "bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'"
 <%  end-%>
+      - "bundle exec rake 'litmus:install_agent[<%=puppet_version%>]'"
+      - "bundle exec rake litmus:install_module"
       bundler_args: 
       dist: trusty
       env: PLATFORMS=<%=platform%>_<%=puppet_version%>

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -109,18 +109,11 @@ matrix:
       <%= key %>: <%= job[key].gsub(/@@SET@@/, set['set']).gsub(/@@COLLECTION@@/, set.fetch('collection', 'puppet6')).gsub(/@@TESTMODE@@/, set.fetch('testmode', 'apply')) %>
 <%   end -%>
 <% end -%>
-<% if @configs['use_litmus'] == true
-  @configs.delete('use_litmus')
-  @configs.merge!('use_litmus'=> {})
-end
-if @configs['use_litmus']
-  @configs['use_litmus']['puppet_collection'] ||= ['puppet5', 'puppet6']
-  @configs['use_litmus']['provision_list'] ||= ['travis_el','travis_deb']
-  @configs['use_litmus']['rvm'] ||= '2.5.3'
-  @configs['use_litmus']['puppet_collection'].each do |puppet_version|
-  @configs['use_litmus']['provision_list'].each do |platform|-%>
+<% if @configs['use_litmus']
+  @configs['litmus']['puppet_collection'].each do |puppet_version|
+  @configs['litmus']['provision_list'].each do |platform|-%>
     -
-<%  if @configs['use_litmus']['install_wget']-%>
+<%  if @configs['litmus']['install_wget']-%>
       before_script: ["bundle exec rake 'litmus:provision_list[<%=platform%>]'", "bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'", "bundle exec rake 'litmus:install_agent[<%=puppet_version%>]'", "bundle exec rake litmus:install_module"]
 <%  else-%>
       before_script: ["bundle exec rake 'litmus:provision_list[<%=platform%>]'", "bundle exec rake 'litmus:install_agent[<%=puppet_version%>]'", "bundle exec rake litmus:install_module"]
@@ -128,7 +121,7 @@ if @configs['use_litmus']
       bundler_args: 
       dist: trusty
       env: PLATFORMS=<%=platform%>_<%=puppet_version%>
-      rvm: <%=@configs['use_litmus']['rvm']%>
+      rvm: <%=@configs['litmus']['rvm']%>
       script: ["bundle exec rake litmus:acceptance:parallel"]
       services: docker
       stage: acceptance


### PR DESCRIPTION
add new variable to _use_litmus_ to configure travis for litmus modules
old functionality is not affected
How to use: in `.sync.yml` file the following code
```
    -
      before_script: ["bundle exec rake 'litmus:provision_list[travis_el]'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
      bundler_args: 
      dist: trusty
      env: PLATFORMS=travis_el_puppet5
      rvm: 2.5.1
      script: ["bundle exec rake litmus:acceptance:parallel"]
      services: docker
      stage: acceptance
      sudo: required
```
can be replaced with this code:
```
use_litmus: true
```
```
by default:
use_litmus: false
litmus:
    provision_list: [travis_deb, travis_el]
    puppet_collection: [puppet5, puppet6]
    rvm: '2.5.3'
    install_wget: no
```
 -
      before_script: ["bundle exec rake 'litmus:provision_list[<%= provision_list%>]'", "bundle exec rake 'litmus:install_agent[<%= puppet_collection%>]'", "bundle exec rake litmus:install_module"]
      bundler_args: 
      dist: trusty
      env: PLATFORMS=<%= provision_list %>_<%= puppet_collection%>
      rvm: <%= rvm%>
      script: ["bundle exec rake litmus:acceptance:parallel"]
      services: docker
      stage: acceptance
      sudo: required```

to update litmus variables should use the following structure:
```
use_litmus: true
litmus:
    provision_list: 
      - travis_test
      - ---travis_deb
      - ---travis_el
```

How to test these changes:
bundle exec rake 'pdksync:run_a_command[pdk convert --template-url https://github.com/lionce/pdk-templates --template-ref FM-8769]'