### PR TITLE
(#290) Do not manually generate YAML in .gitlab-ci.yml

### DIFF
--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -116,35 +116,5 @@ beaker:
 <%   end -%>
 <% end -%>
 <% if configs['custom_jobs'] -%>
-<%   configs['custom_jobs'].each do |job, params| -%>
-<%= job %>:
-<%     params.each do |param, config| -%>
-<%       if (config.is_a?(Array) || config.is_a?(Hash)) && config.empty? -%>
-  <%= param %>: <%= config.inspect %>
-<%       elsif config.is_a?(Array) -%>
-  <%= param %>:
-<%         config.each do |element| -%>
-    - <%= element %>
-<%         end -%>
-<%       elsif config.is_a?(Hash) -%>
-  <%= param %>:
-<%         config.each do |element, value| -%>
-<%           if value.is_a?(Array) -%>
-<%             if value.empty? -%>
-    <%= element %>: <%= value.inspect %>
-<%             else -%>
-    <%= element %>:
-<%               value.each do |content| -%>
-      - <%= content %>
-<%               end -%>
-<%             end -%>
-<%           else -%>
-    <%= element %>: '<%= value %>'
-<%           end -%>
-<%         end -%>
-<%       else -%>
-  <%= param %>: '<%= config %>'
-<%       end -%>
-<%     end %>
-<%   end -%>
+<%=  YAML.dump(configs['custom_jobs']).sub(%r{\A---\r?\n}m, '') %>
 <% end -%>


### PR DESCRIPTION
Use `YAML.dump` to generate the custom job YAML rather than trying to
manually walk the hash and render it.

Given the `.sync.yml` in #290:
```
---
.gitlab-ci.yml:
  override: true
  custom:
    custom_stages:
      - 'unit'
    custom_jobs:
      testjob:
        stage: unit
        image: ruby:2.5.3
        script:
          - 'echo 1'
        artifacts:
          reports:
            junit: 'tmp/*.xml'
```

The rendered `.gitlab-ci.yml` is now:
```
---
stages:
  - unit

before_script:
  - bundle -v
  - rm Gemfile.lock || true
  - gem update --system $RUBYGEMS_VERSION
  - gem --version
  - bundle -v
  - bundle install

testjob:
  stage: unit
  image: ruby:2.5.3
  script:
  - echo 1
  artifacts:
    reports:
      junit: tmp/*.xml
```

Fixes #290 