### PR TITLE
Boolean to remove the before_script section in .gitlab-ci.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Gitlab CI uses a .gitlab-ci.yml file in the root of your repository tell Gitlab 
 | rubygems_mirror | Use a custom rubygems mirror url |
 | image          |Define the Docker image to use, when using the Docker runner. Please see the [Using Docker images](https://docs.gitlab.com/ee/ci/docker/using_docker_images.html) docs for specifics.|
 | custom_before_steps |Allows you to pass additional steps to the GitLab CI before_script. Please see the [.gitlab-ci.yml](https://docs.gitlab.com/ce/ci/yaml/#before_script-and-after_script) docs for specifics.|
-| before_script  |If false, removes the default `before_script` section. Useful if you need a customised Bundler install, or to remove Bundler entirely. If the key is unset the default behaviour is to add `before_script`.|
+| default_before_script  |If false, removes the default `before_script` section. Useful if you need a customised Bundler install, or to remove Bundler entirely. If the key is unset the default behaviour is to add `before_script`.|
 
 ### .pdkignore
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Gitlab CI uses a .gitlab-ci.yml file in the root of your repository tell Gitlab 
 | rubygems_mirror | Use a custom rubygems mirror url |
 | image          |Define the Docker image to use, when using the Docker runner. Please see the [Using Docker images](https://docs.gitlab.com/ee/ci/docker/using_docker_images.html) docs for specifics.|
 | custom_before_steps |Allows you to pass additional steps to the GitLab CI before_script. Please see the [.gitlab-ci.yml](https://docs.gitlab.com/ce/ci/yaml/#before_script-and-after_script) docs for specifics.|
+| before_script  |If false, removes the default `before_script` section. Useful if you need a customised Bundler install, or to remove Bundler entirely. If the key is unset the default behaviour is to add `before_script`.|
 
 ### .pdkignore
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -608,7 +608,7 @@ Gemfile:
           - parallel_spec
         puppet_version: '~> 5'
     # beaker: true
-    before_script: true
+    default_before_script: true
 spec/default_facts.yml:
   ipaddress: "172.16.254.254"
   ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -608,6 +608,7 @@ Gemfile:
           - parallel_spec
         puppet_version: '~> 5'
     # beaker: true
+    before_script: true
 spec/default_facts.yml:
   ipaddress: "172.16.254.254"
   ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"

--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -41,6 +41,7 @@ cache:
 <%   end -%>
 <% end -%>
 
+<% if !configs.has_key?('before_script') || configs['before_script'] -%>
 before_script:
 <% if configs['custom_before_steps'] -%>
 <%   configs['custom_before_steps'].each do |step| -%>
@@ -58,6 +59,7 @@ before_script:
   - gem --version
   - bundle -v
   - bundle install <%= configs['bundler_args'] %>
+<% end -%>
 
 <% if configs['ruby_versions'] -%>
 <%   configs['ruby_versions'].each do |ruby_version, options| -%>

--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -41,7 +41,7 @@ cache:
 <%   end -%>
 <% end -%>
 
-<% if !configs.has_key?('before_script') || configs['before_script'] -%>
+<% if !configs.has_key?('default_before_script') || configs['default_before_script'] -%>
 before_script:
 <% if configs['custom_before_steps'] -%>
 <%   configs['custom_before_steps'].each do |step| -%>


### PR DESCRIPTION
Currently the `.gitlab-ci.yml` template always assumes you are using Bundler, and you will always get this section in the file:

```
before_script:
  - bundle -v
  - rm Gemfile.lock || true
  - gem update --system $RUBYGEMS_VERSION
  - gem --version
  - bundle -v
  - bundle install
```

If you need to do a customised Bundler install, or not use bundler at all (eg: Docker image that's already configured), then this section needs to be removed.

I've added a boolean `default_before_script` to the config of the `.gitlab-ci.yml` file.  Here is an example of how it is used in `.sync.yml`:

```
.gitlab-ci.yml:
  override: true
  custom:
    default_before_script: false
    custom_jobs:
      pdk:
        script:
          - pdk test unit --parallel
        tags:
          - shell_c7
```

If the boolean is not set, the default behaviour remains the same: the `before_script` section is written as before.

Replaces #297 