### PR TITLE
Update travis and gitlab to run `gem update --system` only when requested

### DIFF
--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -55,7 +55,9 @@ before_script:
   - bundle config mirror.http://rubygems.org/ <%= configs['rubygems_mirror'] %>
   - bundle config mirror.https://rubygems.org/ <%= configs['rubygems_mirror'] %>
 <% end -%>
-  - gem update --system $RUBYGEMS_VERSION
+  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+  - "# Set `rubygems_version` in the .sync.yml to set a value"
+  - '[ -z "$RUBYGEMS_VERSION" ] || gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
   - bundle install <%= configs['bundler_args'] %>

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -49,7 +49,9 @@ before_install:
 <% end -%>
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system $RUBYGEMS_VERSION
+  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+  - "# See https://github.com/puppetlabs/pdk-templates/commit/705154d5c437796b821691b707156e1b056d244f for an example of how this was used"
+  - '[ -z "$RUBYGEMS_VERSION" ] || gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
 <% if @configs['before_install_post'] -%>


### PR DESCRIPTION
The `bundle update --system` was originally added as a response to
https://github.com/travis-ci/travis-ci/issues/3531#issuecomment-88311203 .
See https://github.com/puppetlabs/puppetlabs-motd/blob/a56235c5fe6a7514ad3e13e9be840af76c997e5d/.travis.yml#L7-L9 .
Then later it was reinserted in https://github.com/puppetlabs/pdk-templates/commit/705154d5c437796b821691b707156e1b056d244f

Since a few hours, this has started breaking tests because of a change in
bundler: https://travis-ci.org/puppetlabs/puppetlabs-apache/jobs/625596052

```
$ gem update --system $RUBYGEMS_VERSION
Updating rubygems-update
Fetching: rubygems-update-3.1.1.gem (100%)
Successfully installed rubygems-update-3.1.1
Installing RubyGems 3.1.1
  Successfully built RubyGem
  Name: bundler
  Version: 2.1.0
  File: bundler-2.1.0.gem
bundler's executable "bundle" conflicts with /home/travis/.rvm/rubies/ruby-2.5.3/bin/bundle
Overwrite the executable? [yN]

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

The build has been terminated
```

This change makes it so that the update is only carried out when specifically
requested. Not doing the update has been verified working on https://github.com/puppetlabs/puppetlabs-motd/pull/272

The Content team will roll out this change across all modules later today.