### PR TITLE
Change NetworkDevice module to class

### DIFF
--- a/object_templates/transport_device.erb
+++ b/object_templates/transport_device.erb
@@ -1,7 +1,7 @@
 require 'puppet/resource_api/transport/wrapper'
 
-# Initialize the NetworkDevice module if necessary
-module Puppet::Util::NetworkDevice; end
+# Initialize the NetworkDevice class if necessary
+class Puppet::Util::NetworkDevice; end
 
 # The <%= name.capitalize %> module only contains the Device class to bridge from puppet's internals to the Transport.
 # All the heavy lifting is done bye the Puppet::ResourceApi::Transport::Wrapper


### PR DESCRIPTION
This always has been a class (see https://github.com/puppetlabs/puppet/blob/master/lib/puppet/util/network_device.rb). Somehow the network_device.rb is getting pulled in now leading to 
```
Error: Can't load transport for node: NetworkDevice is not a module
```