### PR TITLE
(maint) Fix non-interactive rubygems update

### DIFF
--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -57,7 +57,7 @@ before_script:
 <% end -%>
   - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
   - "# Set `rubygems_version` in the .sync.yml to set a value"
-  - '[ -z "$RUBYGEMS_VERSION" ] || gem update --system $RUBYGEMS_VERSION'
+  - '[ -z "$RUBYGEMS_VERSION" ] || yes | gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
   - bundle install <%= configs['bundler_args'] %>

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -51,7 +51,7 @@ before_install:
   - rm -f Gemfile.lock
   - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
   - "# See https://github.com/puppetlabs/pdk-templates/commit/705154d5c437796b821691b707156e1b056d244f for an example of how this was used"
-  - '[ -z "$RUBYGEMS_VERSION" ] || gem update --system $RUBYGEMS_VERSION'
+  - '[ -z "$RUBYGEMS_VERSION" ] || yes | gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
 <% if @configs['before_install_post'] -%>


### PR DESCRIPTION
Latest rubygems isn't correctly detecting TTYs on some CI platforms like
TravisCI and presents a prompt to overwrite binstubs that causes test
execution to fail (https://github.com/rubygems/rubygems/pull/3040). As
a workaround, we can pipe `yes` to `rubygems update --system` to
automatically confirm the prompt.