### PR TITLE
Fix rubygems update in runners with pipefail set

### DIFF
--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -57,7 +57,8 @@ before_script:
 <% end -%>
   - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
   - "# Set `rubygems_version` in the .sync.yml to set a value"
-  - '[ -z "$RUBYGEMS_VERSION" ] || yes | gem update --system $RUBYGEMS_VERSION'
+  - "# Ignore exit code of SIGPIPE'd yes to not fail with shell's pipefail set"
+  - '[ -z "$RUBYGEMS_VERSION" ] || (yes || true) | gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
   - bundle install <%= configs['bundler_args'] %>

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -51,7 +51,8 @@ before_install:
   - rm -f Gemfile.lock
   - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
   - "# See https://github.com/puppetlabs/pdk-templates/commit/705154d5c437796b821691b707156e1b056d244f for an example of how this was used"
-  - '[ -z "$RUBYGEMS_VERSION" ] || yes | gem update --system $RUBYGEMS_VERSION'
+  - "# Ignore exit code of SIGPIPE'd yes to not fail with shell's pipefail set"
+  - '[ -z "$RUBYGEMS_VERSION" ] || (yes || true) | gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
 <% if @configs['before_install_post'] -%>


### PR DESCRIPTION
If pipefail is set in the runner's shell, then it will fail as 'yes' will receive
SIGPIPE and exit with code 141 which will fail the job. The workaround ignores
the return code of 'yes' whether or not pipefail is set

#303 introduced the problematic yes pipe.