### PR TITLE
Changes for github_changelog_generator Raketask

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |changelog\_project|Sets the github project name for the change\_log\_generator rake task. Optional, if not set it will parse the `source` from the `metadata.json` file|
 |changelog\_since\_tag|Sets the github since_tag for the change\_log\_generator rake task. Required for the changlog rake task.|
 |changelog\_version\_tag\_pattern|Template how the version tag is to be generated. Defaults to `'v%s'` which eventually align with tag\_pattern property of puppet-blacksmith, thus changelog is referring to the correct version tags and compare URLs. |
+|github_site|Override built-in default for public GitHub. Useful for GitHub Enterprise and other. (Example: `github_site = https://git.domain.tld`) |
+|github_endpoint|Override built-in default for public GitHub. Useful for GitHub Enterprise and other. (Example: `github_endpoint = https://git.domain.tld/api/v4`) |
+|gitlab|Allows to work with GitLab (Pending ![GitLab support](https://github.com/github-changelog-generator/github-changelog-generator/pull/657)). (Example: `gitlab = true` # Boolean default is false)|
 |default\_disabled\_lint\_checks| Defines any checks that are to be disabled by default when running lint checks. As default we disable the `--relative` lint check, which compares the module layout relative to the module root. _Does affect **.puppet-lint.rc**._ |
 |extra\_disabled\_lint\_checks| Defines any checks that are to be disabled as extras when running lint checks. No defaults are defined for this configuration. _Does affect **.puppet-lint.rc**._ |
 |extras|An array of extra lines to add into your Rakefile. As an alternative you can add a directory named `rakelib` to your module and files in that directory that end in `.rake` would be loaded by the Rakefile.|

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -77,6 +77,15 @@ PuppetLint.configuration.send('<%= option %>')
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
+<% if @configs['github_site'] -%>
+    config.github_site = <%= @configs['github_site'].inspect %>
+<% end -%>
+<% if @configs['github_endpoint'] -%>
+    config.github_endpoint = <%= @configs['github_endpoint'].inspect %>
+<% end -%>
+<% if @configs['gitlab'] -%>
+    config.gitlab = <%= @configs['gitlab'].inspect %>
+<% end -%>
     config.user = "#{changelog_user}"
     config.project = "#{changelog_project}"
 <% if @configs['changelog_since_tag'] -%>


### PR DESCRIPTION
 - Added github_site for remote server
 - Added github_endpoint for remote server
 - Added gitlab for preparation of gitlab support added in (https://github.com/github-changelog-generator/github-changelog-generator/pull/657)

 These settings will not be added by default. Only if added to `.sync.yml`
 They allow for GitHub Enterprise and Gitlab options down the road.