### PR TITLE
Add `default_facter_version` parameter to `.sync.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 
 | Key            | Description   |
 | :------------- |:--------------|
+|default_facter_version|Sets the [`default_facter_version`](https://github.com/mcanevet/rspec-puppet-facts#specifying-a-default-facter-version) rspec-puppet-facts parameter.|
 |hiera_config|Sets the [`hiera_config`](http://rspec-puppet.com/documentation/configuration/#hiera_config) rspec-puppet parameter.|
 |hiera_config_ruby|Sets the [`hiera_config`](http://rspec-puppet.com/documentation/configuration/#hiera_config) rspec-puppet parameter. A ruby expression returning the path to your hiera.yaml file. `hiera_config` takes precedence if both values `hiera_config` and `hiera_config_ruby` are specified. |
 |mock_with|Defaults to `':mocha'`. Recommended to be set to `':rspec'`, which uses RSpec's built-in mocking library, instead of a third-party one.|

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -40,6 +40,9 @@ end
 
 RSpec.configure do |c|
   c.default_facts = default_facts
+  <%- if @configs['default_facter_version'] -%>
+  c.default_facter_version = '<%= @configs['default_facter_version'] %>'
+  <%- end -%>
   <%- if @configs['hiera_config'] -%>
   c.hiera_config = '<%= @configs['hiera_config'] %>'
   <%- elsif @configs['hiera_config_ruby'] -%>


### PR DESCRIPTION
Currently, the pdk is pinned to facterdb 0.8.2 which doesn't auto-detect facter versions as well as we could wish, but users can override the facter version. This new parameter in the sync file allows the setting to persist across a `pdk update`.