### PR TITLE
(PDK-1609) Prefer os.name over os.family in hiera.yaml

### DIFF
--- a/moduleroot_init/hiera.yaml.erb
+++ b/moduleroot_init/hiera.yaml.erb
@@ -8,14 +8,14 @@ defaults:  # Used for any hierarchy level that omits these keys.
 hierarchy:
   - name: "osfamily/major release"
     paths:
+        # Used to distinguish between Debian and Ubuntu
+      - "os/%{facts.os.name}/%{facts.os.release.major}.yaml"
       - "os/%{facts.os.family}/%{facts.os.release.major}.yaml"
         # Used for Solaris
       - "os/%{facts.os.family}/%{facts.kernelrelease}.yaml"
-        # Used to distinguish between Debian and Ubuntu
-      - "os/%{facts.os.name}/%{facts.os.release.major}.yaml"
   - name: "osfamily"
     paths:
-      - "os/%{facts.os.family}.yaml"
       - "os/%{facts.os.name}.yaml"
+      - "os/%{facts.os.family}.yaml"
   - name: 'common'
     path: 'common.yaml'


### PR DESCRIPTION
The `os.name` fact is more specific than the `os.family` fact and so it
should be higher in the hierarchy.