### PR TITLE
Update to latest ruby version supported by the agent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-sudo: false
-dist: trusty
+---
+os: linux
+dist: xenial
 language: generic
 env:
   - PDK=release PDK_FRONTEND=noninteractive

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |litmus|Allows you to update default config values. Its sub keys are `provision_list`, `puppet_collection`, `rvm`, `install_wget` which are detailed below.|
 |litmus\\**puppet_collection**|Allows you to specify the puppet version under test. Default test are ran on _puppet 5_ and _puppet 6_.|
 |litmus\\**provision_list**|Allows you to specify the platforms list under test. Default test are ran on platformes defined in provision.yaml file under _travis_deb_ and _travis_el_|
-|litmus\\**rvm**|Allows you to specify the ruby version under test. Default it is set to _2.5.3_|
+|litmus\\**rvm**|Allows you to specify the ruby version under test. Default it is set to _2.5.7_|
 |litmus\\**install_wget**|Allows you to enable automatic installation of wget on the platform under test. We need this when installing agent on travis_deb platforms. Default it is disabled. |
 |user|This string needs to be set to the Puppet Forge user name. To enable deployment the secure key also needs to be set.|
 |secure|This string needs to be set to the encrypted password to enable deployment. See [https://docs.travis-ci.com/user/encryption-keys/#usage](https://docs.travis-ci.com/user/encryption-keys/#usage) for instructions on how to encrypt your password.|

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -59,12 +59,12 @@
     - spec
     - acceptance
   ruby_versions:
-    - 2.5.3
+    - 2.5.7
   bundler_args: --without system_tests
   docker_sets:
   docker_defaults:
     # values will replace @@SET@@ with the docker_sets' value
-    rvm: 2.5.3
+    rvm: 2.5.7
     sudo: required
     dist: trusty
     services: docker
@@ -79,7 +79,7 @@
       rvm: 2.4.5
       stage: spec
     - env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
-      rvm: 2.5.3
+      rvm: 2.5.7
       stage: spec
   branches:
     - master
@@ -88,7 +88,7 @@
   litmus:
     provision_list: [travis_deb, travis_el]
     puppet_collection: [puppet5, puppet6]
-    rvm: '2.5.3'
+    rvm: '2.5.7'
     install_wget: no
   notifications:
     email: false
@@ -603,7 +603,7 @@ Gemfile:
         - 'vendor/bundle'
     bundler_args: '--without system_tests --path vendor/bundle --jobs $(nproc)'
     ruby_versions:
-      '2.5.3':
+      '2.5.7':
         checks:
           - 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'
           - parallel_spec


### PR DESCRIPTION
Amongst other things, this avoids a ruby segfault with concurrent-ruby-1.1.6 (see https://github.com/ruby-concurrency/concurrent-ruby/issues/849)