### PR TITLE
(PDK-1591) Add option to enable legacy_facts puppet-lint plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ For more on basic usage and more detailed description of the PDK in action pleas
 
 The following is a description and explaination of each of the keys within config\_defaults. This will help clarify the default settings we choose to apply to pdk modules.
 
+### common
+
+> A namespace for settings that affect multiple templates
+
+| Key                    | Description |
+|:-----------------------|:------------|
+| disable\_legacy\_facts | Set to `true` to configure PDK to prevent the use of [legacy Facter facts][legacy_facts_doc]. Currently this will install and enable the [legacy\_facts][legacy_facts_pl_plugin] plugin for puppet-lint for use during `pdk validate`. |
+
+
 ### .gitattributes
 
 >A .gitattributes file in your repo allows you to ensure consistent git settings.
@@ -301,3 +310,6 @@ appveyor.yml:
 ## Further Notes <a name="notes"></a>
 
 Please note that the early version of this template contained only a 'moduleroot' directory, and did not have a 'moduleroot\_init'. The PDK 'pdk new module' command will still work with templates that only have 'moduleroot', however the 'pdk convert' command will fail if the template does not have a 'moduleroot_init' directory present. To remedy this please use the up to date version of the template.
+
+[legacy_facts_doc]: https://puppet.com/docs/facter/latest/core_facts.html#legacy-facts
+[legacy_facts_pl_plugin]: https://github.com/mmckinst/puppet-lint-legacy_facts-check

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,4 +1,6 @@
 ---
+common:
+  disable_legacy_facts: false
 .gitattributes:
   include:
     '*.rb': 'eol=lf'

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -63,6 +63,16 @@ minor_version = ruby_version_segments[0..1].join('.')
   (@configs['required'].keys + ((@configs['optional'] || {}).keys)).uniq.each do |key|
     groups[key] = (@configs['required'][key] || []) + ((@configs['optional'] || {})[key] || [])
   end
+
+  if respond_to?(:config_for)
+    common_config = config_for('common')
+
+    if common_config['disable_legacy_facts']
+      groups[':development'] << {
+        'gem' => 'puppet-lint-legacy_facts-check',
+      }
+    end
+  end
 -%>
 <% groups.each do |group, gems| -%>
 group <%= group %> do


### PR DESCRIPTION
Keen observers may note that only one template is affected by this change in contradiction to the description of the `common` namespace introduced here. In a future release I plan to add the ability to disable legacy facts during rspec-puppet catalogue testing which will also be controlled by this setting.