### PR TITLE
Added strict_variables config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |mock_with|Defaults to `':mocha'`. Recommended to be set to `':rspec'`, which uses RSpec's built-in mocking library, instead of a third-party one.|
 |spec_overrides|An array of extra lines to add into your `spec_helper.rb`. Can be used as an alternative to `spec_helper_local`|
 |strict_level| Defines the [Puppet Strict configuration parameter](https://puppet.com/docs/puppet/5.4/configuration.html#strict). Defaults to `:warning`. Other values are: `:error` and `:off`. `:error` provides strictest level checking and is encouraged.|
+|strict_variables| Defines the [Puppet Strict Variables configuration parameter](https://puppet.com/docs/puppet/5.4/configuration.html#strict_variables). Defaults to `true` however due to `puppetlabs_spec_helper` forced override (https://github.com/puppetlabs/puppetlabs_spec_helper/blob/070ecb79a63cb8fa10f46532c413c055e2697682/lib/puppetlabs_spec_helper/module_spec_helper.rb#L71). Set to `false` to align with true default or with `STRICT_VARIABLES=no` environment setting.|
 |coverage_report|Enable [rspec-puppet coverage reports](https://rspec-puppet.com/documentation/coverage/). Defaults to `false`|
 |minimum_code_coverage_percentage|The desired code coverage percentage required for tests to pass. Defaults to `0`|
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -625,3 +625,4 @@ spec/spec_helper.rb:
   coverage_report: false
   minimum_code_coverage_percentage: 0
   strict_level: ":warning"
+  strict_variables: true

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -48,13 +48,16 @@ RSpec.configure do |c|
   <%- elsif @configs['hiera_config_ruby'] -%>
   c.hiera_config = <%= @configs['hiera_config_ruby'] %>
   <%- end -%>
-  <%- if @configs['strict_level'] -%>
   c.before :each do
+    <%- if @configs['strict_level'] -%>
     # set to strictest setting for testing
     # by default Puppet runs at warning level
     Puppet.settings[:strict] = <%= @configs['strict_level'] %>
+    <%- end -%>
+    <%- if @configs['strict_variables'] -%>
+    Puppet.settings[:strict_variables] = <%= @configs['strict_variables'] %>
+    <%- end -%>
   end
-  <%- end -%>
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
   c.after(:suite) do
     <%- if @configs['coverage_report'] -%>


### PR DESCRIPTION
Currently due to https://github.com/puppetlabs/puppetlabs_spec_helper/blob/070ecb79a63cb8fa10f46532c413c055e2697682/lib/puppetlabs_spec_helper/module_spec_helper.rb#L71 the default of `false` is overridden. 
This is to allow you to set the value back to `false` and avoid having to use `STRICT_VARIABLES=no` on a unit test run.

@DavidS 