### PR TITLE
Disable RuboCop Style/BracesAroundHashParameters

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -159,6 +159,10 @@ Rakefile:
       Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to be consistent then.
       EnforcedStyle: braces_for_chaining
 
+    Style/BracesAroundHashParameters:
+      Description: Braces are required by Ruby 2.7. Cop removed from RuboCop v0.80.0. See https://github.com/rubocop-hq/rubocop/pull/7643
+      Enabled: false
+
     Style/ClassAndModuleChildren:
       Description: Compact style reduces the required amount of indentation.
       EnforcedStyle: compact

--- a/rubocop/defaults-0.49.1.yml
+++ b/rubocop/defaults-0.49.1.yml
@@ -223,7 +223,6 @@
 - Style/BeginBlock
 - Style/BlockComments
 - Style/BlockDelimiters
-- Style/BracesAroundHashParameters
 - Style/CaseEquality
 - Style/CharacterLiteral
 - Style/ClassAndModuleCamelCase


### PR DESCRIPTION
The `Style/BracesAroundHashParameters` cop would flag "redundant" uses
of braces to create hashes in Ruby method arguments. Ruby 2.7 requires
these braces to disambiguate hash literals from keyword arguments and
will issue warnings. The cop has been removed from RuboCop v0.80.0.

See: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
See: https://github.com/rubocop-hq/rubocop/pull/7643