### PR TITLE
(IAC-805) - Update to Travis template

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |litmus\\**provision_list**|Allows you to specify the platforms list under test. Default test are ran on platformes defined in provision.yaml file under _travis_deb_ and _travis_el_|
 |litmus\\**rvm**|Allows you to specify the ruby version under test. Default it is set to _2.5.7_|
 |litmus\\**install_wget**|Allows you to enable automatic installation of wget on the platform under test. We need this when installing agent on travis_deb platforms. Default it is disabled. |
+|litmus\\**complex\\collection**|Allows you to specify multiple collections of `puppet_collection` and `provision_list`, allowing you to set certain OS to only run on certain Puppet versions. |
 |user|This string needs to be set to the Puppet Forge user name. To enable deployment the secure key also needs to be set.|
 |secure|This string needs to be set to the encrypted password to enable deployment. See [https://docs.travis-ci.com/user/encryption-keys/#usage](https://docs.travis-ci.com/user/encryption-keys/#usage) for instructions on how to encrypt your password.|
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -87,6 +87,7 @@ common:
     - master
     - /^v\d/
   use_litmus: false
+  use_litmus_complex: false
   litmus:
     provision_list: [travis_deb, travis_el]
     puppet_collection: [puppet5, puppet6]

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -112,8 +112,14 @@ jobs:
 <%   end -%>
 <% end -%>
 <% if @configs['use_litmus']
-  @configs['litmus']['puppet_collection'].each do |puppet_version|
-  @configs['litmus']['provision_list'].each do |platform|-%>
+  configs = if @configs['litmus']['complex']
+              (@configs['litmus']['complex'] + [{'collection' =>@configs['litmus'] }])
+            else
+              [{'collection' =>@configs['litmus'] }]
+            end
+  configs.each do |config|
+  config['collection']['puppet_collection'].each do |puppet_version|
+  config['collection']['provision_list'].each do |platform|-%>
     -
       before_script:
       - "bundle exec rake 'litmus:provision_list[<%=platform%>]'"
@@ -128,6 +134,7 @@ jobs:
       script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
       services: docker
       stage: acceptance
+<%    end -%>
 <%   end -%>
 <%  end -%>
 <% end -%>


### PR DESCRIPTION
An update to the travis template to allow you to make a more complex test environment. An example of what can be given is:
```
  litmus:
    provision_list:
      - travis_deb
      - travis_el6
      - travis_el7
      - ---travis_el
    complex:
    - collection:
        puppet_collection:
        - puppet6
        provision_list:
        - travis_ub_6
    - collection:
        puppet_collection:
        - puppet5
        provision_list:
        - travis_ub_5
```