### PR TITLE
Add global_variables key for GitLab CI to set defaults that can be overridden by jobs

### DIFF
--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -86,6 +86,11 @@ before_script:
 <%       if options['rubygems_version'] -%>
     RUBYGEMS_VERSION: '<%= options['rubygems_version'] -%>'
 <%       end -%>
+<% if configs.has_key?('global_variables') -%>
+<%   configs['global_variables'].each do |key, value| -%>
+    <%= key %>: '<%= value %>'
+<%   end -%>
+<% end -%>
 <%       if options['allow_failure'] -%>
 <%         if options['allow_failure'].include?(check) -%>
   allow_failure: true


### PR DESCRIPTION
This would incorporate global variables in the job level variables.
This could probably be even turned into some sort of YAML anchor instead