### PR TITLE
Add starter Forge publish GitHub action

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -8,6 +8,8 @@ common:
     '*.pp': 'eol=lf'
     '*.sh': 'eol=lf'
     '*.epp': 'eol=lf'
+.github/workflows/publish.yaml:
+  enabled: false # requires a FORGE_API_KEY GitHub secret
 .gitignore:
   required: &ignorepaths
       - '.git/'

--- a/moduleroot/.github/workflows/publish.yaml
+++ b/moduleroot/.github/workflows/publish.yaml
@@ -1,0 +1,23 @@
+name: Build and publish to Puppet Forge
+
+on:
+ push:
+  tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: ${{ false }} # remove this line and create a FORGE_API_KEY secret to enable the job
+    steps:
+    - name: Get latest tag
+      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+    - name: Clone repository
+      uses: actions/checkout@v1
+      with:
+        ref: ${{ env.RELEASE_VERSION }}
+    - name: Build and publish module
+      uses: barnumbirr/action-forge-publish@v2.3.0
+      env:
+       FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
+       REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases

--- a/moduleroot/.github/workflows/publish.yaml.erb
+++ b/moduleroot/.github/workflows/publish.yaml.erb
@@ -1,3 +1,4 @@
+<% if configs['enabled'] -%>
 name: Build and publish to Puppet Forge
 
 on:
@@ -8,7 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ false }} # remove this line and create a FORGE_API_KEY secret to enable the job
     steps:
     - name: Get latest tag
       run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
@@ -21,3 +21,10 @@ jobs:
       env:
        FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
        REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases
+<% else -%>
+# Add the following key to your .sync.yml and create a FORGE_API_KEY GitHub
+# secret to enable this job.
+#
+# .github/workflows/publish.yaml:
+#   enabled: true
+<% end -%>


### PR DESCRIPTION
Adds a starter GitHub action. Users will have to enable it in their `sync.yml` or local template fork for now.