### PR TITLE
(IAC-940) Add a remove_includes configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |simplecov|Set to `true` to enable collecting ruby code coverage.|
 |test\_script|This defines the test script that will be executed. For our purposes the default is set to `bundle exec rake %CHECK%`. As appveyor iterates through the test matrix as we defined above, it resolves the variable CHECK and runs the resulting command. For example, our last test script would be executed as `bundle exec rake spec`, which would run the spec tests of the module.|
 |use_litmus|Configures Appveyor to be able to use Litmus for acceptance testing jobs|
+|remove_includes |Allows you to remove includes set in `config_defaults.yml`.|
 
 ### Rakefile
 

--- a/moduleroot/appveyor.yml.erb
+++ b/moduleroot/appveyor.yml.erb
@@ -30,7 +30,7 @@ environment:
   SIMPLECOV: yes
 <% end -%>
   matrix:
-<%- (@configs['matrix'] + (@configs['matrix_extras'] || [])).each do |matrix| -%>
+<%- (((@configs['matrix']) + (@configs['matrix_extras'] || [])) - (@configs['remove_includes'] || [])).each do |matrix| -%>
     -
   <%- matrix.each do |key, value| -%>
     <%- if (@configs['spec_type'] && value =~ %r{spec}) -%>


### PR DESCRIPTION
Add a remove_includes configuration option

Prior to this commit, the user could not remove the default included checks in appveyor file.

After this commit, the user can specify default checks that should be removed
in the remove_includes configuration setting in .sync.yml

This allows for a .sync.yml like the following that replaces static check from 24 to 25

```appveyor.yml:
  use_litmus: true
  spec_type: spec
  remove_includes:
    -
      RUBY_VERSION: 24-x64
      CHECK: syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
  matrix_extras:
  -
    RUBY_VERSION: 25-x64
    CHECK: syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop```