### PR TITLE
Fix disabling of BracesAroundHashParameters

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -325,7 +325,6 @@ Rakefile:
     Style/BarePercentLiterals:
     Style/BlockComments:
     Style/BlockDelimiters:
-    Style/BracesAroundHashParameters:
     Style/CharacterLiteral:
     Style/ClassCheck:
     Style/ClassMethods:


### PR DESCRIPTION
Despite https://github.com/puppetlabs/pdk-templates/pull/329 (which
aimed to disable this cop), in the last round of module updates, it is
set as `enabled: true` in all puppetlabs modules.
Removing the line from the cleanup_cops seems to fix this.