### PR TITLE
(#350) Update deprecated globals

### DIFF
--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -29,39 +29,42 @@ variables:
 <%   end -%>
 <% end -%>
 
+<% if configs['image'] || configs['cache'] || !configs.has_key?('default_before_script') || configs['default_before_script'] -%>
+default:
+<% end -%>
 <% if configs['image'] -%>
-image: <%= configs['image'] %>
+  image: <%= configs['image'] %>
 
 <% end -%>
 <% if configs['cache'] -%>
-cache:
-  paths:
+  cache:
+    paths:
 <%   configs['cache']['paths'].each do |path| -%>
-    - <%= path %>
+      - <%= path %>
 <%   end -%>
 <% end -%>
 
 <% if !configs.has_key?('default_before_script') || configs['default_before_script'] -%>
-before_script:
+  before_script:
 <% if configs['custom_before_steps'] -%>
 <%   configs['custom_before_steps'].each do |step| -%>
-  - <%= step %>
+    - <%= step %>
 <%   end -%>
 <% end -%>
-  - bundle -v
-  - rm Gemfile.lock || true
+    - bundle -v
+    - rm Gemfile.lock || true
 <% if configs['rubygems_mirror'] -%>
-  - gem sources -a <%= configs['rubygems_mirror'] %> --remove https://rubygems.org/
-  - bundle config mirror.http://rubygems.org/ <%= configs['rubygems_mirror'] %>
-  - bundle config mirror.https://rubygems.org/ <%= configs['rubygems_mirror'] %>
+    - gem sources -a <%= configs['rubygems_mirror'] %> --remove https://rubygems.org/
+    - bundle config mirror.http://rubygems.org/ <%= configs['rubygems_mirror'] %>
+    - bundle config mirror.https://rubygems.org/ <%= configs['rubygems_mirror'] %>
 <% end -%>
-  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
-  - "# Set `rubygems_version` in the .sync.yml to set a value"
-  - "# Ignore exit code of SIGPIPE'd yes to not fail with shell's pipefail set"
-  - '[ -z "$RUBYGEMS_VERSION" ] || (yes || true) | gem update --system $RUBYGEMS_VERSION'
-  - gem --version
-  - bundle -v
-  - bundle install <%= configs['bundler_args'] %>
+    - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+    - "# Set `rubygems_version` in the .sync.yml to set a value"
+    - "# Ignore exit code of SIGPIPE'd yes to not fail with shell's pipefail set"
+    - '[ -z "$RUBYGEMS_VERSION" ] || (yes || true) | gem update --system $RUBYGEMS_VERSION'
+    - gem --version
+    - bundle -v
+    - bundle install <%= configs['bundler_args'] %>
 <% end -%>
 
 <% if configs['ruby_versions'] -%>


### PR DESCRIPTION
According to https://docs.gitlab.com/ee/ci/yaml/README.html#globally-defined-image-services-cache-before_script-after_script:

> Defining `image`, `services`, `cache`, `before_script`, and `after_script` globally is deprecated. Support could be removed from a future release.

This change moves `image`, `cache`, and `before_script` to the top-level `default` key instead.

Fixes #350.