### PR TITLE
Add gitpod support for puppet modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ Gitlab CI uses a .gitlab-ci.yml file in the root of your repository tell Gitlab 
 | custom_before_steps |Allows you to pass additional steps to the GitLab CI before_script. Please see the [.gitlab-ci.yml](https://docs.gitlab.com/ce/ci/yaml/#before_script-and-after_script) docs for specifics.|
 | default_before_script  |If false, removes the default `before_script` section. Useful if you need a customised Bundler install, or to remove Bundler entirely. If the key is unset the default behaviour is to add `before_script`.|
 
+### Gitpod configuration
+If you are using Gitpod you will need to opt-in and enable gitpod support for pdk-templates.  To do this simple set the following configurations.
+
+```
+.gitpod.Dockerfile:
+  unmanaged: false
+.gitpod.yml:
+  unmanaged: false  
+
+```
+
 ### .pdkignore
 
 >A .pdkignore file in your repo allows you to specify files to ignore when building a module package with `pdk build`.

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -625,6 +625,10 @@ Gemfile:
         puppet_version: '~> 5'
     # beaker: true
     default_before_script: true
+.gitpod.Dockerfile:
+  unmanaged: true
+.gitpod.yml:
+  unmanaged: true    
 spec/default_facts.yml:
   ipaddress: "172.16.254.254"
   ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"

--- a/moduleroot/.gitpod.Dockerfile
+++ b/moduleroot/.gitpod.Dockerfile
@@ -1,0 +1,15 @@
+FROM gitpod/workspace-full
+RUN sudo wget https://apt.puppet.com/puppet-tools-release-bionic.deb && \
+    wget https://apt.puppetlabs.com/puppet6-release-bionic.deb && \
+    sudo dpkg -i puppet6-release-bionic.deb && \
+    sudo dpkg -i puppet-tools-release-bionic.deb && \
+    sudo apt-get update && sudo apt-get install -y pdk zsh puppet-agent
+RUN sudo usermod -s $(which zsh) gitpod && \
+    sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" && \
+    echo "plugins=(git gitignore github gem pip bundler python ruby docker docker-compose)" >> /home/gitpod/.zshrc && \
+    echo 'PATH="$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin"'  >> /home/gitpod/.zshrc && \
+    sudo /opt/puppetlabs/puppet/bin/gem install puppet-debugger hub -N && \
+    mkdir -p /home/gitpod/.config/puppet && \
+    /opt/puppetlabs/puppet/bin/ruby -r yaml -e "puts ({'disabled' => true}).to_yaml" > /home/gitpod/.config/puppet/analytics.yml
+RUN rm -f puppet6-release-bionic.deb  puppet-tools-release-bionic.deb
+ENTRYPOINT /usr/bin/zsh

--- a/moduleroot/.gitpod.yml
+++ b/moduleroot/.gitpod.yml
@@ -1,0 +1,9 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: pdk bundle install
+
+vscode:
+  extensions:
+    - puppet.puppet-vscode@0.28.0:g5CT+jlJywUtP9HoX4DIZg==


### PR DESCRIPTION
  * This adds initial support for gitpod puppet development.  Any user
    who opens the module in gitpod would automatically
    stand up a PDK and puppet development environment.

    While this is a first stab at this file I expect further customizations
    to follow and allow the user to utilize the sync or config_defaults
    to tweak their own unique gitpod.

    I decided to leave the clickable banner that normally goes in the readme out of this changeset as I don't know
    what the user's gitpod link would actually be.  I am sure a config variable might help with this but decided to KISS.

An example of this setup can be viewed here by clicking this link: [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://gitlab.com/nwops/control-repo.git)
