### PR TITLE
Default new modules to rspec-mocks

### DIFF
--- a/moduleroot_init/.sync.yml.erb
+++ b/moduleroot_init/.sync.yml.erb
@@ -5,4 +5,6 @@
 #
 # See https://github.com/puppetlabs/pdk-templates/blob/main/config_defaults.yml
 # for the default values.
---- {}
+---
+spec/spec_helper.rb:
+  mock_with: rspec

--- a/moduleroot_init/.sync.yml.erb
+++ b/moduleroot_init/.sync.yml.erb
@@ -7,4 +7,4 @@
 # for the default values.
 ---
 spec/spec_helper.rb:
-  mock_with: rspec
+  mock_with: ":rspec"


### PR DESCRIPTION
For the longest time we've been recommending rspec-mocks as the default mocking framework, but haven't been able to break backwards compatibility for modules using both rspec-mocks and mocha together. Now, at least for new modules we can do better.