### PR TITLE
(fix) Set rubocop ruby version to 2.4

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -7,7 +7,7 @@ defaults = {
   ],
   'AllCops' => {
     'DisplayCopNames' => true,
-    'TargetRubyVersion' => '2.1',
+    'TargetRubyVersion' => '2.5',
     'Include' => [
       './**/*.rb',
     ],

--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -7,7 +7,7 @@ defaults = {
   ],
   'AllCops' => {
     'DisplayCopNames' => true,
-    'TargetRubyVersion' => '2.5',
+    'TargetRubyVersion' => '2.4',
     'Include' => [
       './**/*.rb',
     ],


### PR DESCRIPTION
2.1 has some changes to hash syntax.
using 2.1 shows false positives