### PR TITLE
Avoid second failure if provision doesn't create inventory

### DIFF
--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -200,11 +200,13 @@ jobs:
     - name: Remove test environment
       if: ${{ always() }}
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
-        echo ::group::=== REQUEST ===
-        cat request.json || true
-        echo
-        echo ::endgroup::
+        if [ -f inventory.yaml ]; then
+          buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+          echo ::group::=== REQUEST ===
+          cat request.json || true
+          echo
+          echo ::endgroup::
+        fi
 
     - name: Record removal times
       if: ${{ always() }}

--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -198,11 +198,13 @@ jobs:
     - name: Remove test environment
       if: ${{ always() }}
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
-        echo ::group::=== REQUEST ===
-        cat request.json || true
-        echo
-        echo ::endgroup::
+        if [ -f inventory.yaml ]; then
+          buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+          echo ::group::=== REQUEST ===
+          cat request.json || true
+          echo
+          echo ::endgroup::
+        fi
 
     - name: Record removal times
       if: ${{ always() }}


### PR DESCRIPTION
Without an inventory this would never be able to create a
correct tear_down call. Instead it is causing a second error
that is confusing the github actions log viewer. This change
avoids running the `litmus:tear_down` rake task when provisioning
has failed.