### PR TITLE
(maint) Update Ruby version for Appveyor linting checks

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -111,7 +111,7 @@ appveyor.yml:
   appveyor_bundle_install: "bundle install --jobs 4 --retry 2 --without system_tests"
   use_litmus: false
   matrix:
-    - RUBY_VERSION: 24-x64
+    - RUBY_VERSION: 25-x64
       CHECK: "syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     - PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24


### PR DESCRIPTION
When puppet7 becomes available and the linting check installs puppet7, it will fail as Puppet7 only supports ruby 2.5+

I have tested the template change locally and can confirm it only changes the Ruby version for appveyor. I have also put up a PR with the change to confirm it works as expected. PR can be found here: https://github.com/puppetlabs/puppetlabs-acl/pull/223