### PR TITLE
(SEC-250) Pin non-github provided actions to a specific SHA

### DIFF
--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: "Honeycomb: Start recording"
-      uses: kvrhdn/gha-buildevents@v1.0.2
+      uses: kvrhdn/gha-buildevents@5be4636b81803713c94d7cb7e3a4b85d759df112 # pin@v1.0.2
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}
@@ -96,7 +96,7 @@ jobs:
         echo 'collection=${{ matrix.collection }}' >> $BUILDEVENT_FILE
 
     - name: "Honeycomb: Start recording"
-      uses: kvrhdn/gha-buildevents@v1.0.2
+      uses: kvrhdn/gha-buildevents@5be4636b81803713c94d7cb7e3a4b85d759df112 # pin@v1.0.2
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Slack Workflow Notification
-        uses: Gamesight/slack-workflow-status@master
+        uses: Gamesight/slack-workflow-status@88ee95b73b4669825883ddf22747966204663e58 # pin@master
         with:
           # Required Input
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: "Honeycomb: Start recording"
-      uses: kvrhdn/gha-buildevents@v1.0.2
+      uses: kvrhdn/gha-buildevents@5be4636b81803713c94d7cb7e3a4b85d759df112 # pin@v1.0.2
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}
@@ -94,7 +94,7 @@ jobs:
         echo 'collection=${{ matrix.collection }}' >> $BUILDEVENT_FILE
 
     - name: "Honeycomb: Start recording"
-      uses: kvrhdn/gha-buildevents@v1.0.2
+      uses: kvrhdn/gha-buildevents@5be4636b81803713c94d7cb7e3a4b85d759df112 # pin@v1.0.2
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}


### PR DESCRIPTION
> Malicious code can be inserted into any GitHub action, even those which are tagged.
-- https://julienrenaux.fr/2019/12/20/github-actions-security-risk/

This is mitigated through using https://github.com/mheap/pin-github-action to update non github-provided actions to use a full SHA instead of relying on mutable tags or branch names.