### PR TITLE
(IAC-1307) Add Spec tests to nightly and pr_test GHActions configs

### DIFF
--- a/moduleroot/.github/workflows/spec.yml.erb
+++ b/moduleroot/.github/workflows/spec.yml.erb
@@ -1,0 +1,130 @@
+<% common = config_for('common') -%>
+name: "Spec Tests"
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+  pull_request:
+
+env:
+<% if common['honeycomb'] -%>
+  HONEYCOMB_WRITEKEY: <%= common['honeycomb']['writekey'] %>
+  HONEYCOMB_DATASET: <%= common['honeycomb']['dataset'] %>
+<% end -%>
+<% if common['service_url'] -%>
+  SERVICE_URL: <%= common['service_url'] %>
+<% end -%>
+
+jobs:
+  setup_matrix:
+    name: "Setup Test Matrix"
+    runs-on: ubuntu-20.04
+    outputs:
+      spec_matrix: ${{ steps.get-matrix.outputs.spec_matrix }}
+
+    steps:
+      - name: "Honeycomb: Start recording"
+        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
+        with:
+          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
+          dataset: ${{ env.HONEYCOMB_DATASET }}
+          job-status: ${{ job.status }}
+
+      - name: "Honeycomb: Start first step"
+        run: |
+          echo STEP_ID=setup-environment >> $GITHUB_ENV
+          echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+      - name: Checkout Source
+        uses: actions/checkout@v2
+        if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+
+      - name: Activate Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+        with:
+          ruby-version: "2.7"
+          bundler-cache: true
+
+      - name: Print bundle environment
+        if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+        run: |
+          echo ::group::bundler environment
+          buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
+          echo ::endgroup::
+
+      - name: "Honeycomb: Record Setup Environment time"
+        if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+        run: |
+          buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
+          echo STEP_ID=Setup-Acceptance-Test-Matrix >> $GITHUB_ENV
+          echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+      - name: Setup Acceptance Test Matrix
+        id: get-matrix
+        run: |
+          if [ '${{ github.repository_owner }}' == '<%= common['owner'] %>' ]; then
+            buildevents cmd $TRACE_ID $STEP_ID matrix_from_metadata -- bundle exec matrix_from_metadata_v2
+          else
+            echo  "::set-output name=spec_matrix::{}"
+          fi
+
+      - name: "Honeycomb: Record Setup Test Matrix time"
+        if: ${{ always() }}
+        run: |
+          buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Test Matrix'
+
+  Spec:
+    name: "Spec Tests (Puppet: ${{matrix.puppet_version}}, Ruby Ver: ${{matrix.ruby_version}})"
+    needs:
+      - setup_matrix
+    if: ${{ needs.setup_matrix.outputs.spec_matrix != '{}' }}
+
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.setup_matrix.outputs.spec_matrix)}}
+
+    env:
+      BUILDEVENT_FILE: '../buildevents.txt'
+      PUPPET_GEM_VERSION: ${{ matrix.puppet_version }}
+
+    steps:
+      - run: |
+          echo "SANITIZED_PUPPET_VERSION=$(echo '${{ matrix.puppet_version }}' | sed 's/~> //g')" >> $GITHUB_ENV
+
+      - run: |
+          echo 'puppet_version=${{ env.SANITIZED_PUPPET_VERSION }}' >> $BUILDEVENT_FILE
+
+      - name: "Honeycomb: Start first step"
+        run: |
+          echo "STEP_ID=${{ env.SANITIZED_PUPPET_VERSION }}-spec" >> $GITHUB_ENV
+          echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+      - name: "Honeycomb: Start recording"
+        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
+        with:
+          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
+          dataset: ${{ env.HONEYCOMB_DATASET }}
+          job-status: ${{ job.status }}
+          matrix-key: ${{ env.SANITIZED_PUPPET_VERSION }}
+
+      - name: Checkout Source
+        uses: actions/checkout@v2
+
+      - name: "Activate Ruby ${{ matrix.ruby_version }}"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{matrix.ruby_version}}
+          bundler-cache: true
+
+      - name: Print bundle environment
+        run: |
+          echo ::group::bundler environment
+          buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
+          echo ::endgroup::
+
+      - name: Run parallel_spec tests
+        run: |
+          buildevents cmd $TRACE_ID $STEP_ID 'rake parallel_spec Puppet ${{ matrix.puppet_version }}, Ruby ${{ matrix.ruby_version }}' -- bundle exec rake parallel_spec


### PR DESCRIPTION
## Description

This change adds a new workflow to run spec (unit) tests as a
standalone manual job and as options to the 'Nightly' and 'PR'
tests.

## Testing
- [x] Changes tested on `puppetlabs-testing` module - https://github.com/puppetlabs/puppetlabs-testing/pull/352 (_<-- also see here for an example of how this will look_)

## Pre-requisites before merging
- [x] #371 merged and `puppet-module-gems` version `1.0` released
- [x] Supported modules `Gemfile` bumped to use `puppet-module-gems ~> 1.0`
- [ ] https://github.com/puppetlabs/puppet_litmus/pull/395 merged