### PR TITLE
Fix Include syntax for new rubocop

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -9,7 +9,7 @@ defaults = {
     'DisplayCopNames' => true,
     'TargetRubyVersion' => '2.4',
     'Include' => [
-      './**/*.rb',
+      '**/*.rb',
     ],
     'Exclude'=> [
       'bin/*',

--- a/object_templates/provider_type.erb
+++ b/object_templates/provider_type.erb
@@ -21,13 +21,13 @@ EOS
   features: [],
   attributes: {
     ensure: {
-      type:    'Enum[present, absent]',
-      desc:    'Whether this resource should be present or absent on the target system.',
+      type: 'Enum[present, absent]',
+      desc: 'Whether this resource should be present or absent on the target system.',
       default: 'present',
     },
     name: {
-      type:      'String',
-      desc:      'The name of the resource you want to manage.',
+      type: 'String',
+      desc: 'The name of the resource you want to manage.',
       behaviour: :namevar,
     },
   },


### PR DESCRIPTION
Note how the original `Include` value causes no files to be scanned.

See [rubocop docs](https://docs.rubocop.org/rubocop/configuration.html#includingexcluding-files) for background.

```
david@zion:~/git/pdksync/modules_pdksync/provision (main)$ grep -A5 AllCops .rubocop.yml
AllCops:
  DisplayCopNames: true
  TargetRubyVersion: '2.4'
  Include:
  - "./**/*.rb"
  Exclude:
david@zion:~/git/pdksync/modules_pdksync/provision (main)$ bundle exec rake rubocop:auto_correct
Running RuboCop...
Inspecting 0 files

0 files inspected, no offenses detected
david@zion:~/git/pdksync/modules_pdksync/provision (main)$ grep -A5 AllCops .rubocop.yml
AllCops:
  DisplayCopNames: true
  TargetRubyVersion: '2.4'
  Include:
  - "**/*.rb" # changed this
  Exclude:
david@zion:~/git/pdksync/modules_pdksync/provision (main)$ bundle exec rake rubocop:auto_correct
Running RuboCop...
Inspecting 12 files
W...C.W...C.

Offenses:

lib/task_helper.rb:48:25: W: [Corrected] Lint/RedundantCopDisableDirective: Unnecessary disabling of Style/DoubleNegation.
```