### PR TITLE
Remove Layout/HashAlignment from the default cleanup cops

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -201,7 +201,6 @@ Rakefile:
     Bundler/OrderedGems:
     Layout/AccessModifierIndentation:
     Layout/ArrayAlignment:
-    Layout/HashAlignment:
     Layout/ParameterAlignment:
     Layout/BlockEndNewline:
     Layout/CaseIndentation:

--- a/rubocop/cleanup_cops.yml
+++ b/rubocop/cleanup_cops.yml
@@ -2,7 +2,6 @@
 - Bundler/OrderedGems
 - Layout/AccessModifierIndentation
 - Layout/ArrayAlignment
-- Layout/HashAlignment
 - Layout/ParameterAlignment
 - Layout/BlockEndNewline
 - Layout/CaseIndentation


### PR DESCRIPTION
The hash alignment does not work satifactorily and produces a lot of unsightly artifacts.