### PR TITLE
Update how we handle at-risk action sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,10 +353,11 @@ Since this still has some overhead, we exclude some "big-name" action maintainer
 ### Updating actions guitelines
 
 To keep efforts low when updating actions, we list all forked actions here.
-To keep confusion to a minimum, the version we use is always on a `pdk-templates` branch.
-This way we can update (`git fetch`/`git push`) forked repositories with no prejudice, test out the changes, and only then update the `pdk-templates` branch.
+To keep confusion to a minimum, the version we use is always on a `pdk-templates-v1` branch.
+This way we can update (`git fetch`/`git push`) forked repositories with no prejudice, test out the changes, and only then update the `pdk-templates-v1` branch.
+If we later need to support multiple versions of an action as we roll out changes, we can increment the `-v1` part in the branch name to manage multiple versions.
 
-* [kvrhdn/gha-buildevents](https://github.com/kvrhdn/gha-buildevents) ➡️ [puppetlabs/kvrhdn-gha-buildevents](https://github.com/puppetlabs/kvrhdn-gha-buildevents/tree/pdk-templates)
-* [Gamesight/slack-workflow-status](https://github.com/Gamesight/slack-workflow-status) ➡️ [puppetlabs/Gamesight-slack-workflow-status](https://github.com/puppetlabs/Gamesight-slack-workflow-status/tree/pdk-templates)
+* [kvrhdn/gha-buildevents](https://github.com/kvrhdn/gha-buildevents) ➡️ [puppetlabs/kvrhdn-gha-buildevents](https://github.com/puppetlabs/kvrhdn-gha-buildevents/tree/pdk-templates-v1)
+* [Gamesight/slack-workflow-status](https://github.com/Gamesight/slack-workflow-status) ➡️ [puppetlabs/Gamesight-slack-workflow-status](https://github.com/puppetlabs/Gamesight-slack-workflow-status/tree/pdk-templates-v1)
 
 The repos have restricted access only to [@modules](https://github.com/orgs/puppetlabs/teams/modules) team members.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you are using Gitpod you will need to opt-in and enable gitpod support for pd
 .gitpod.Dockerfile:
   unmanaged: false
 .gitpod.yml:
-  unmanaged: false  
+  unmanaged: false
 
 ```
 
@@ -331,3 +331,32 @@ Please note that the early version of this template contained only a 'moduleroot
 
 [legacy_facts_doc]: https://puppet.com/docs/facter/latest/core_facts.html#legacy-facts
 [legacy_facts_pl_plugin]: https://github.com/mmckinst/puppet-lint-legacy_facts-check
+
+## Security Considerations on Github Actions
+
+As explained in [Use GitHub actions at your own risk](https://julienrenaux.fr/2019/12/20/github-actions-security-risk/),
+when running github actions from outside the organisation,
+there is a risk that symbolic references get taken over by malicious actors.
+Similar things happened before in other ecosystems and other packaging registries.
+The blog post goes on to suggest pinning to specific SHAs and provides some tooling to do so.
+The downsides for us are that the tooling doesn't work well with our ERB templating,
+and the additional cost of updating the SHAs across all modules.
+Instead we fork at-risk actions into the puppetlabs namespace and use them from there.
+This allows us to consume updates at our pace and deploy changes across all modules without delay,
+while avoiding actions that surreptitiously change while we're not looking.
+
+Since this still has some overhead, we exclude some "big-name" action maintainers:
+* Anything maintained by Github, e.g. [https://github.com/actions](https://github.com/actions)
+* Anything maintained as part of a bigger OSS project we're using, like [https://github.com/ruby/setup-ruby](https://github.com/ruby/setup-ruby)
+* Anything maintained by a Puppet employee
+
+### Updating actions guitelines
+
+To keep efforts low when updating actions, we list all forked actions here.
+To keep confusion to a minimum, the version we use is always on a `pdk-templates` branch.
+This way we can update (`git fetch`/`git push`) forked repositories with no prejudice, test out the changes, and only then update the `pdk-templates` branch.
+
+* [kvrhdn/gha-buildevents](https://github.com/kvrhdn/gha-buildevents) ➡️ [puppetlabs/kvrhdn-gha-buildevents](https://github.com/puppetlabs/kvrhdn-gha-buildevents/tree/pdk-templates)
+* [Gamesight/slack-workflow-status](https://github.com/Gamesight/slack-workflow-status) ➡️ [puppetlabs/Gamesight-slack-workflow-status](https://github.com/puppetlabs/Gamesight-slack-workflow-status/tree/pdk-templates)
+
+The repos have restricted access only to [@modules](https://github.com/orgs/puppetlabs/teams/modules) team members.

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Since this still has some overhead, we exclude some "big-name" action maintainer
 To keep efforts low when updating actions, we list all forked actions here.
 To keep confusion to a minimum, the version we use is always on a `pdk-templates-v1` branch.
 This way we can update (`git fetch`/`git push`) forked repositories with no prejudice, test out the changes, and only then update the `pdk-templates-v1` branch.
+That said, the branches used in pdk-templates should only contain upstream code and changes already in an upstream PR to minimize the diff we're carrying.
 If we later need to support multiple versions of an action as we roll out changes, we can increment the `-v1` part in the branch name to manage multiple versions.
 
 * [kvrhdn/gha-buildevents](https://github.com/kvrhdn/gha-buildevents) ➡️ [puppetlabs/kvrhdn-gha-buildevents](https://github.com/puppetlabs/kvrhdn-gha-buildevents/tree/pdk-templates-v1)

--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: "Honeycomb: Start recording"
-      uses: kvrhdn/gha-buildevents@3822dbd38231e62d41108de1b1009f9eb3957f76 # pin@v1
+      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}
@@ -96,7 +96,7 @@ jobs:
         echo 'collection=${{ matrix.collection }}' >> $BUILDEVENT_FILE
 
     - name: "Honeycomb: Start recording"
-      uses: kvrhdn/gha-buildevents@3822dbd38231e62d41108de1b1009f9eb3957f76 # pin@v1
+      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Slack Workflow Notification
-        uses: Gamesight/slack-workflow-status@88ee95b73b4669825883ddf22747966204663e58 # pin@master
+        uses: puppetlabs/Gamesight-slack-workflow-status@pdk-templates
         with:
           # Required Input
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: "Honeycomb: Start recording"
-      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates
+      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}
@@ -96,7 +96,7 @@ jobs:
         echo 'collection=${{ matrix.collection }}' >> $BUILDEVENT_FILE
 
     - name: "Honeycomb: Start recording"
-      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates
+      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Slack Workflow Notification
-        uses: puppetlabs/Gamesight-slack-workflow-status@pdk-templates
+        uses: puppetlabs/Gamesight-slack-workflow-status@pdk-templates-v1
         with:
           # Required Input
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: "Honeycomb: Start recording"
-      uses: kvrhdn/gha-buildevents@5be4636b81803713c94d7cb7e3a4b85d759df112 # pin@v1.0.2
+      uses: kvrhdn/gha-buildevents@3822dbd38231e62d41108de1b1009f9eb3957f76 # pin@v1
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}
@@ -96,7 +96,7 @@ jobs:
         echo 'collection=${{ matrix.collection }}' >> $BUILDEVENT_FILE
 
     - name: "Honeycomb: Start recording"
-      uses: kvrhdn/gha-buildevents@5be4636b81803713c94d7cb7e3a4b85d759df112 # pin@v1.0.2
+      uses: kvrhdn/gha-buildevents@3822dbd38231e62d41108de1b1009f9eb3957f76 # pin@v1
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}

--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: "Honeycomb: Start recording"
-      uses: kvrhdn/gha-buildevents@5be4636b81803713c94d7cb7e3a4b85d759df112 # pin@v1.0.2
+      uses: kvrhdn/gha-buildevents@3822dbd38231e62d41108de1b1009f9eb3957f76 # pin@v1
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}
@@ -94,7 +94,7 @@ jobs:
         echo 'collection=${{ matrix.collection }}' >> $BUILDEVENT_FILE
 
     - name: "Honeycomb: Start recording"
-      uses: kvrhdn/gha-buildevents@5be4636b81803713c94d7cb7e3a4b85d759df112 # pin@v1.0.2
+      uses: kvrhdn/gha-buildevents@3822dbd38231e62d41108de1b1009f9eb3957f76 # pin@v1
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}

--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: "Honeycomb: Start recording"
-      uses: kvrhdn/gha-buildevents@3822dbd38231e62d41108de1b1009f9eb3957f76 # pin@v1
+      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}
@@ -94,7 +94,7 @@ jobs:
         echo 'collection=${{ matrix.collection }}' >> $BUILDEVENT_FILE
 
     - name: "Honeycomb: Start recording"
-      uses: kvrhdn/gha-buildevents@3822dbd38231e62d41108de1b1009f9eb3957f76 # pin@v1
+      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}

--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: "Honeycomb: Start recording"
-      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates
+      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}
@@ -94,7 +94,7 @@ jobs:
         echo 'collection=${{ matrix.collection }}' >> $BUILDEVENT_FILE
 
     - name: "Honeycomb: Start recording"
-      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates
+      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
       with:
         apikey: ${{ env.HONEYCOMB_WRITEKEY }}
         dataset: ${{ env.HONEYCOMB_DATASET }}


### PR DESCRIPTION
## Security Considerations on Github Actions

As explained in [Use GitHub actions at your own risk](https://julienrenaux.fr/2019/12/20/github-actions-security-risk/),
when running github actions from outside the organisation,
there is a risk that symbolic references get taken over by malicious actors.
Similar things happened before in other ecosystems and other packaging registries.
The blog post goes on to suggest pinning to specific SHAs and provides some tooling to do so.
The downsides for us are that the tooling doesn't work well with our ERB templating,
and the additional cost of updating the SHAs across all modules.
Instead we fork at-risk actions into the puppetlabs namespace and use them from there.
This allows us to consume updates at our pace and deploy changes across all modules without delay,
while avoiding actions that surreptitiously change while we're not looking.

Since this still has some overhead, we exclude some "big-name" action maintainers:
* Anything maintained by Github, e.g. [https://github.com/actions](https://github.com/actions)
* Anything maintained as part of a bigger OSS project we're using, like [https://github.com/ruby/setup-ruby](https://github.com/ruby/setup-ruby)
* Anything maintained by a Puppet employee

### Updating actions guitelines

To keep efforts low when updating actions, we list all forked actions here.
To keep confusion to a minimum, the version we use is always on a `pdk-templates` branch.
This way we can update (`git fetch`/`git push`) forked repositories with no prejudice, test out the changes, and only then update the `pdk-templates` branch.

* [kvrhdn/gha-buildevents](https://github.com/kvrhdn/gha-buildevents) ➡️ [puppetlabs/kvrhdn-gha-buildevents](https://github.com/puppetlabs/kvrhdn-gha-buildevents/tree/pdk-templates)
* [Gamesight/slack-workflow-status](https://github.com/Gamesight/slack-workflow-status) ➡️ [puppetlabs/Gamesight-slack-workflow-status](https://github.com/puppetlabs/Gamesight-slack-workflow-status/tree/pdk-templates)

The repos have restricted access only to [@modules](https://github.com/orgs/puppetlabs/teams/modules) team members.