### PR TITLE
(maint) Fix GitHub acceptance test setup when not common owner

### DIFF
--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -63,7 +63,6 @@ jobs:
 
     - name: Setup Acceptance Test Matrix
       id: get-matrix
-      if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
       run: |
         if [ '${{ github.repository_owner }}' == '<%= common['owner'] %>' ]; then
           buildevents cmd $TRACE_ID $STEP_ID matrix_from_metadata -- bundle exec matrix_from_metadata
@@ -79,6 +78,7 @@ jobs:
   Acceptance:
     needs:
       - setup_matrix
+    if: ${{ needs.setup_matrix.outputs.matrix != '{}' }}
 
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
Prior to this PR, when the user submitting the PR was not the common
owner, the GitHub acceptance test setup would fail. The failure was because
there was a missing matrix due to an if statement. This PR generates
an empty matrix and skips acceptance tests if the matrix is empty.

Here was the error from when the common owner was not the repo owner. This was because the if/else bash did not run so the matrix was never set.

```
Error when evaluating 'strategy' for job 'Acceptance'. (Line: 80, Col: 15): Error reading JToken from JsonReader. Path '', line 0, position 0.,(Line: 80, Col: 15): Unexpected value ''
```

This fixes the issue where there is an empty matrix, which would have resulted in the following error.

```
Error when evaluating 'strategy' for job 'Acceptance'. (Line: 80, Col: 15): Matrix must define at least one vector
```