### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,10 @@ Gemfile:
   required:
     ':system_tests':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
+        version: '~> 0.4'
         platforms: ruby
       - gem: 'puppet-module-win-system-r#{minor_version}'
+        version: '~> 0.4'
         platforms:
           - mswin
           - mingw


### PR DESCRIPTION
Version 1.0 of puppet-module-posix-system does not require breaker anymore.