### PR TITLE
Use ruby/setup-ruby Github action

### DIFF
--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -31,7 +31,7 @@ jobs:
 
     - name: "Honeycomb: Start first step"
       run: |
-        echo STEP_ID=0 >> $GITHUB_ENV
+        echo STEP_ID=setup-environment >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
 
     - name: Checkout Source
@@ -45,6 +45,20 @@ jobs:
         ruby-version: "2.7"
         bundler-cache: true
 
+    - name: Print bundle environment
+      if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+      run: |
+        echo ::group::bundler environment
+        buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
+        echo ::endgroup::
+
+    - name: "Honeycomb: Record Setup Environment time"
+      if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+      run: |
+        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
+        echo STEP_ID=Setup-Acceptance-Test-Matrix >> $GITHUB_ENV
+        echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
     - name: Setup Acceptance Test Matrix
       id: get-matrix
       if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
@@ -55,7 +69,7 @@ jobs:
           echo  "::set-output name=matrix::{}"
         fi
 
-    - name: "Honeycomb: Record setup time"
+    - name: "Honeycomb: Record Setup Test Matrix time"
       if: ${{ always() }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Test Matrix'
@@ -99,18 +113,18 @@ jobs:
         ruby-version: "2.7"
         bundler-cache: true
 
-    - name: "Honeycomb: Record Ruby Setup time"
-      if: ${{ always() }}
-      run: |
-        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Ruby Setup'
-        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-2 >> $GITHUB_ENV
-        echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
     - name: Print bundle environment
       run: |
         echo ::group::bundler environment
         buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
         echo ::endgroup::
+
+    - name: "Honeycomb: Record Setup Environment time"
+      if: ${{ always() }}
+      run: |
+        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
+        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-2 >> $GITHUB_ENV
+        echo STEP_START=$(date +%s) >> $GITHUB_ENV
 
     - name: Provision test environment
       run: |

--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -39,29 +39,11 @@ jobs:
       if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
 
     - name: Activate Ruby 2.7
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
       with:
         ruby-version: "2.7"
-
-    - name: Cache gems
-      uses: actions/cache@v2
-      if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
-      with:
-        path: vendor/gems
-        key: ${{ runner.os }}-${{ github.event_name }}-${{ hashFiles('**/Gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ github.event_name }}-
-          ${{ runner.os }}-
-
-    - name: Install gems
-      if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
-      run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle config path vendor/gems' -- bundle config path vendor/gems
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle config jobs 8' -- bundle config jobs 8
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle config retry 3' -- bundle config retry 3
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle install' -- bundle install
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle clean' -- bundle clean
+        bundler-cache: true
 
     - name: Setup Acceptance Test Matrix
       id: get-matrix
@@ -112,43 +94,23 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Activate Ruby 2.7
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: "2.7"
+        bundler-cache: true
 
-    - name: Cache gems
-      uses: actions/cache@v2
-      with:
-        path: vendor/gems
-        key: ${{ runner.os }}-${{ github.event_name }}-${{ hashFiles('**/Gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ github.event_name }}-
-          ${{ runner.os }}-
-
-    - name: "Honeycomb: Record cache setup time"
+    - name: "Honeycomb: Record Ruby Setup time"
       if: ${{ always() }}
       run: |
-        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Cache retrieval'
+        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Ruby Setup'
         echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-2 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
 
-    - name: Bundler Setup
+    - name: Print bundle environment
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle config path vendor/gems' -- bundle config path vendor/gems
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle config jobs 8' -- bundle config jobs 8
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle config retry 3' -- bundle config retry 3
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle install' -- bundle install
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle clean' -- bundle clean
         echo ::group::bundler environment
         buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
         echo ::endgroup::
-
-    - name: "Honeycomb: Record Bundler Setup time"
-      if: ${{ always() }}
-      run: |
-        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Bundler Setup'
-        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-3 >> $GITHUB_ENV
-        echo STEP_START=$(date +%s) >> $GITHUB_ENV
 
     - name: Provision test environment
       run: |
@@ -174,7 +136,7 @@ jobs:
       run: |
         echo ::group::honeycomb step
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Deploy test system'
-        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-4 >> $GITHUB_ENV
+        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-3 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
         echo ::endgroup::
 
@@ -186,7 +148,7 @@ jobs:
       if: ${{ always() }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Run acceptance tests'
-        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-5 >> $GITHUB_ENV
+        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-4 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
 
     - name: Remove test environment

--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -29,7 +29,7 @@ jobs:
 
     - name: "Honeycomb: Start first step"
       run: |
-        echo STEP_ID=0 >> $GITHUB_ENV
+        echo STEP_ID=setup-environment >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
 
     - name: Checkout Source
@@ -43,6 +43,20 @@ jobs:
         ruby-version: "2.7"
         bundler-cache: true
 
+    - name: Print bundle environment
+      if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+      run: |
+        echo ::group::bundler environment
+        buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
+        echo ::endgroup::
+
+    - name: "Honeycomb: Record Setup Environment time"
+      if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+      run: |
+        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
+        echo STEP_ID=Setup-Acceptance-Test-Matrix >> $GITHUB_ENV
+        echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
     - name: Setup Acceptance Test Matrix
       id: get-matrix
       if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
@@ -53,7 +67,7 @@ jobs:
           echo  "::set-output name=matrix::{}"
         fi
 
-    - name: "Honeycomb: Record setup time"
+    - name: "Honeycomb: Record Setup Test Matrix time"
       if: ${{ always() }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Test Matrix'
@@ -92,42 +106,22 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Activate Ruby 2.7
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: "2.7"
+        bundler-cache: true
 
-    - name: Cache gems
-      uses: actions/cache@v2
-      with:
-        path: vendor/gems
-        key: ${{ runner.os }}-${{ github.event_name }}-${{ hashFiles('**/Gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ github.event_name }}-
-          ${{ runner.os }}-
-
-    - name: "Honeycomb: Record cache setup time"
-      if: ${{ always() }}
+    - name: Print bundle environment
       run: |
-        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Cache retrieval'
-        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-2 >> $GITHUB_ENV
-        echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
-    - name: Bundler Setup
-      run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle config path vendor/gems' -- bundle config path vendor/gems
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle config jobs 8' -- bundle config jobs 8
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle config retry 3' -- bundle config retry 3
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle install' -- bundle install
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle clean' -- bundle clean
         echo ::group::bundler environment
         buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
         echo ::endgroup::
 
-    - name: "Honeycomb: Record Bundler Setup time"
+    - name: "Honeycomb: Record Setup Environment time"
       if: ${{ always() }}
       run: |
-        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Bundler Setup'
-        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-3 >> $GITHUB_ENV
+        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
+        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-2 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
 
     - name: Provision test environment
@@ -154,7 +148,7 @@ jobs:
       run: |
         echo ::group::honeycomb step
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Deploy test system'
-        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-4 >> $GITHUB_ENV
+        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-3 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
         echo ::endgroup::
 
@@ -166,7 +160,7 @@ jobs:
       if: ${{ always() }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Run acceptance tests'
-        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-5 >> $GITHUB_ENV
+        echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-4 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
 
     - name: Remove test environment

--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -37,29 +37,11 @@ jobs:
       if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
 
     - name: Activate Ruby 2.7
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
       with:
         ruby-version: "2.7"
-
-    - name: Cache gems
-      uses: actions/cache@v2
-      if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
-      with:
-        path: vendor/gems
-        key: ${{ runner.os }}-${{ github.event_name }}-${{ hashFiles('**/Gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ github.event_name }}-
-          ${{ runner.os }}-
-
-    - name: Install gems
-      if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
-      run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle config path vendor/gems' -- bundle config path vendor/gems
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle config jobs 8' -- bundle config jobs 8
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle config retry 3' -- bundle config retry 3
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle install' -- bundle install
-        buildevents cmd $TRACE_ID $STEP_ID 'bundle clean' -- bundle clean
+        bundler-cache: true
 
     - name: Setup Acceptance Test Matrix
       id: get-matrix


### PR DESCRIPTION
The ruby/setup-ruby action is actually maintained by the Ruby people themselves. It has built in caching with the proper behavior. Not only is it easier to read (less syncing going on), it's also likely to be maintained properly. For example, to get proper caching of gems, bundle lock should run to get a Gemfile.lock which gives you a correct cache.  This action does it for you.

Note I didn't test it myself since I don't use PDK, but we've been using this in Voxpupuli (https://github.com/voxpupuli/modulesync_config/blob/master/moduleroot/.github/workflows/ci.yml.erb) and it works well in my experience. The only thing we don't currently do is to run on push as well. That means we don't have a shared cache ready and caches are now scoped to a user. It looks like pdk-templates is in the same setup, but due to the nightly tests it probably gets away with this.