### PR TITLE
(MAINT) Fix bundler resolution issues for older puppet versions

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -592,9 +592,22 @@ Gemfile:
     ':system_tests':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         version: '~> 1.0'
+        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
+        platforms: ruby
+      - gem: 'puppet-module-posix-system-r#{minor_version}'
+        version: '~> 0.4'
+        condition: "Gem::Requirement.create('< 6.11.0').satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms: ruby
       - gem: 'puppet-module-win-system-r#{minor_version}'
         version: '~> 1.0'
+        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
+        platforms:
+          - mswin
+          - mingw
+          - x64_mingw
+      - gem: 'puppet-module-win-system-r#{minor_version}'
+        version: '~> 0.4'
+        condition: "Gem::Requirement.create('< 6.11.0').satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms:
           - mswin
           - mingw

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -58,6 +58,10 @@ end
 ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
+puppet_version = ENV['PUPPET_GEM_VERSION']
+facter_version = ENV['FACTER_GEM_VERSION']
+hiera_version = ENV['HIERA_GEM_VERSION']
+
 <%
   groups = {}
   (@configs['required'].keys + ((@configs['optional'] || {}).keys)).uniq.each do |key|
@@ -99,10 +103,6 @@ group <%= group %> do
 <%   end -%>
 end
 <% end -%>
-
-puppet_version = ENV['PUPPET_GEM_VERSION']
-facter_version = ENV['FACTER_GEM_VERSION']
-hiera_version = ENV['HIERA_GEM_VERSION']
 
 gems = {}
 


### PR DESCRIPTION
The way bundler resolves the puppet_litmus dependencies is currently
preventing dependency resolution when Puppet version is less than
6.11.0. This updates the PDK-generated Gemfile to fall back to the
pre-1.0 releases of the `puppet-module-*-system` gems when the Puppet
version is less than 6.11.0.