### PR TITLE
(MAINT) Remove puppet-module-system gems for older Puppet versions

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -590,20 +590,9 @@ Gemfile:
         version: '~> 1.0'
         condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms: ruby
-      - gem: 'puppet-module-posix-system-r#{minor_version}'
-        version: '~> 0.4'
-        condition: "Gem::Requirement.create('< 6.11.0').satisfied_by?(Gem::Version.new(puppet_version.dup))"
-        platforms: ruby
       - gem: 'puppet-module-win-system-r#{minor_version}'
         version: '~> 1.0'
         condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
-        platforms:
-          - mswin
-          - mingw
-          - x64_mingw
-      - gem: 'puppet-module-win-system-r#{minor_version}'
-        version: '~> 0.4'
-        condition: "Gem::Requirement.create('< 6.11.0').satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms:
           - mswin
           - mingw


### PR DESCRIPTION
Following @DavidS's suggestion, I think this is simpler than trying to resolve all the dependency conflicts...