### PR TITLE
(FIX) Ensure system PMG gem installed when PUPPET_GEM_VERSION nil

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -588,11 +588,11 @@ Gemfile:
     ':system_tests':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         version: '~> 1.0'
-        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
+        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup)) || puppet_version.nil?"
         platforms: ruby
       - gem: 'puppet-module-win-system-r#{minor_version}'
         version: '~> 1.0'
-        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
+        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup)) || puppet_version.nil?"
         platforms:
           - mswin
           - mingw


### PR DESCRIPTION
# Description
Prior to this change, if PUPPET_GEM_VERSION was not set, the system
Puppet Module Gems gem would not be installed, which would not have
installed Litmus. This was causing issues on CI pipelines as there
is a dependency on a helper script in Litmus during set up,
regardless as to whether PUPPET_GEM_VERSION is set or not.

This was introduced in the changes within #385 and #386.

With this change, we now ensure that the system PMG gem is installed
if PUPPET_GEM_VERSION is undefined.

# Testing / Verification
This issue manifested on the `puppetlabs-apache` module. 
- [x] Confirmation of issue prior to this fix: https://github.com/puppetlabs/puppetlabs-apache/pull/2115/checks?check_run_id=1682707758
- [x] Confirmation that this fix resolves issue: https://github.com/puppetlabs/puppetlabs-apache/runs/1682775186