### PR TITLE
system_tests group handling

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -589,9 +589,20 @@ Gemfile:
         version: '~> 1.0'
         condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms: ruby
+      - gem: 'puppet-module-posix-system-r#{minor_version}'
+        version: '~> 0.4'
+        condition: "Gem::Requirement.create('< 6.11.0').satisfied_by?(Gem::Version.new(puppet_version.dup))"
+        platforms: ruby
       - gem: 'puppet-module-win-system-r#{minor_version}'
         version: '~> 1.0'
         condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
+        platforms:
+          - mswin
+          - mingw
+          - x64_mingw
+      - gem: 'puppet-module-win-system-r#{minor_version}'
+        version: '~> 0.4'
+        condition: "Gem::Requirement.create('< 6.11.0').satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms:
           - mswin
           - mingw

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -587,11 +587,11 @@ Gemfile:
     ':system_tests, optional: true':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         version: '~> 1.0'
-        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup)) || puppet_version.nil?"
+        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms: ruby
       - gem: 'puppet-module-win-system-r#{minor_version}'
         version: '~> 1.0'
-        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup)) || puppet_version.nil?"
+        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms:
           - mswin
           - mingw

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -69,7 +69,6 @@ common:
     - acceptance
   ruby_versions:
     - 2.5.7
-  bundler_args: --without system_tests
   docker_sets:
   docker_defaults:
     # values will replace @@SET@@ with the docker_sets' value
@@ -77,8 +76,8 @@ common:
     sudo: required
     dist: trusty
     services: docker
-    bundler_args: --with system_tests
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=@@COLLECTION@@ BEAKER_set=@@SET@@ BEAKER_TESTMODE=@@TESTMODE@@
+    # BUNDLE_WITH=system_tests requires pre-1.0.0 puppet-module-gems OR manual setup of the beaker gems
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=@@COLLECTION@@ BEAKER_set=@@SET@@ BEAKER_TESTMODE=@@TESTMODE@@ BUNDLE_WITH=system_tests
     script: bundle exec rake beaker
     stage: acceptance
   includes:
@@ -108,7 +107,7 @@ common:
 .yardopts:
   markup: markdown
 appveyor.yml:
-  appveyor_bundle_install: "bundle install --jobs 4 --retry 2 --without system_tests"
+  appveyor_bundle_install: "bundle install --jobs 4 --retry 2"
   use_litmus: false
   matrix:
     - RUBY_VERSION: 25-x64
@@ -585,7 +584,7 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
-    ':system_tests':
+    ':system_tests, optional: true':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         version: '~> 1.0'
         condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup)) || puppet_version.nil?"

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -587,22 +587,9 @@ Gemfile:
     ':system_tests, optional: true':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         version: '~> 1.0'
-        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
-        platforms: ruby
-      - gem: 'puppet-module-posix-system-r#{minor_version}'
-        version: '~> 0.4'
-        condition: "Gem::Requirement.create('< 6.11.0').satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms: ruby
       - gem: 'puppet-module-win-system-r#{minor_version}'
         version: '~> 1.0'
-        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
-        platforms:
-          - mswin
-          - mingw
-          - x64_mingw
-      - gem: 'puppet-module-win-system-r#{minor_version}'
-        version: '~> 0.4'
-        condition: "Gem::Requirement.create('< 6.11.0').satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms:
           - mswin
           - mingw

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -68,7 +68,9 @@ script:
 <% else -%>
   - 'bundle exec rake $CHECK'
 <% end -%>
+<% if @configs['bundler_args'] -%>
 bundler_args: <%= @configs['bundler_args'] %>
+<% end -%>
 rvm:
 <% @configs['ruby_versions'].each do |ruby_version| -%>
   - <%= ruby_version %>

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -58,10 +58,6 @@ end
 ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
-puppet_version = ENV['PUPPET_GEM_VERSION']
-facter_version = ENV['FACTER_GEM_VERSION']
-hiera_version = ENV['HIERA_GEM_VERSION']
-
 <%
   groups = {}
   (@configs['required'].keys + ((@configs['optional'] || {}).keys)).uniq.each do |key|
@@ -103,6 +99,10 @@ group <%= group %> do
 <%   end -%>
 end
 <% end -%>
+
+puppet_version = ENV['PUPPET_GEM_VERSION']
+facter_version = ENV['FACTER_GEM_VERSION']
+hiera_version = ENV['HIERA_GEM_VERSION']
 
 gems = {}
 

--- a/moduleroot/appveyor.yml.erb
+++ b/moduleroot/appveyor.yml.erb
@@ -48,6 +48,7 @@ for:
       - ACCEPTANCE: yes
   install:
     - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+    - set BUNDLE_WITH=system_tests
     - bundle install --jobs 4 --retry 2
     - type Gemfile.lock
   test_script:


### PR DESCRIPTION
## Problem Description

Since moving `puppet_litmus` to the `system_tests` group, a few issues have cropped up:

* on older ruby versions or when running older puppet versions, litmus is not a valid install, through the litmus->bolt->puppet>=6 dependency chain. This happens:
  * in some unit-test cases we need to run older puppet versions
  * in the PDK when choosing older puppet versions 

Initial attempts to address this included avoiding installing litmus conditional on the `PUPPET_GEM_VERSION`. This turned out to be more complicated based on the limits of the `Gem::Requirement` API used and the diverse set of use-cases of the `PUPPET_GEM_VERSION`: 
* PDK provides a single-digit major puppet version
* unit testing in CI commonly provides optimistic version constraints like `~> 5.0`

The latter form does not allow comparison in the gem API, rendering this approach untenable. See #385, #386 and #389 for reference.

In https://github.com/puppetlabs/pdk/pull/935 I've even implemented forcing the PDK to make bundler ignore the `system_tests` group in regular operations.

## This Change

This PR reverts the original three PRs and instead makes the `system_tests` group optional by using bundler's `optional` flag to do so.

* this ensures that only environments that explicitly request litmus (through use of `BUNDLE_WITH=system_tests`) will have litmus installed
* with litmus' experimental state that gives us another layer of protection from accidents in customer environments
* this way we don't need a PDK change, which reduces time to repair by a lot
* this change also fixes up the CI configuration files to set BUNDLE_WITH where required and remove now redundant `--without system_tests` 

## Open Issues

* This requires `BUNDLE_WITH=system_tests` set in all environments - especially IC's local dev environments - where litmus is to be used
* **MORE PROBLEMATIC**: This makes litmus unavailable in the PDK, as `BUNDLE_WITH` does not get passed through to the `pdk bundle` subcommand:
```
$ env | sort | grep WITH
BUNDLE_WITH=system_tests
david@zion:~/git/pdksync/modules_pdksync/puppetlabs-powershell (pdksync)$ pdk bundle exec env | sort | grep WITH
pdk (INFO): Using Ruby 2.5.8
pdk (INFO): Using Puppet 7.1.0
$ 
```