### PR TITLE
Revert litmus protection

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -588,11 +588,11 @@ Gemfile:
     ':system_tests':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         version: '~> 1.0'
-        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup)) || puppet_version.nil?"
+        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms: ruby
       - gem: 'puppet-module-win-system-r#{minor_version}'
         version: '~> 1.0'
-        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup)) || puppet_version.nil?"
+        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms:
           - mswin
           - mingw

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -588,22 +588,9 @@ Gemfile:
     ':system_tests':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         version: '~> 1.0'
-        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
-        platforms: ruby
-      - gem: 'puppet-module-posix-system-r#{minor_version}'
-        version: '~> 0.4'
-        condition: "Gem::Requirement.create('< 6.11.0').satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms: ruby
       - gem: 'puppet-module-win-system-r#{minor_version}'
         version: '~> 1.0'
-        condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
-        platforms:
-          - mswin
-          - mingw
-          - x64_mingw
-      - gem: 'puppet-module-win-system-r#{minor_version}'
-        version: '~> 0.4'
-        condition: "Gem::Requirement.create('< 6.11.0').satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms:
           - mswin
           - mingw

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -590,9 +590,20 @@ Gemfile:
         version: '~> 1.0'
         condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms: ruby
+      - gem: 'puppet-module-posix-system-r#{minor_version}'
+        version: '~> 0.4'
+        condition: "Gem::Requirement.create('< 6.11.0').satisfied_by?(Gem::Version.new(puppet_version.dup))"
+        platforms: ruby
       - gem: 'puppet-module-win-system-r#{minor_version}'
         version: '~> 1.0'
         condition: "Gem::Requirement.create(['>= 6.11.0', '< 8.0.0']).satisfied_by?(Gem::Version.new(puppet_version.dup))"
+        platforms:
+          - mswin
+          - mingw
+          - x64_mingw
+      - gem: 'puppet-module-win-system-r#{minor_version}'
+        version: '~> 0.4'
+        condition: "Gem::Requirement.create('< 6.11.0').satisfied_by?(Gem::Version.new(puppet_version.dup))"
         platforms:
           - mswin
           - mingw

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -58,10 +58,6 @@ end
 ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
-puppet_version = ENV['PUPPET_GEM_VERSION']
-facter_version = ENV['FACTER_GEM_VERSION']
-hiera_version = ENV['HIERA_GEM_VERSION']
-
 <%
   groups = {}
   (@configs['required'].keys + ((@configs['optional'] || {}).keys)).uniq.each do |key|
@@ -103,6 +99,10 @@ group <%= group %> do
 <%   end -%>
 end
 <% end -%>
+
+puppet_version = ENV['PUPPET_GEM_VERSION']
+facter_version = ENV['FACTER_GEM_VERSION']
+hiera_version = ENV['HIERA_GEM_VERSION']
 
 gems = {}
 


### PR DESCRIPTION
This has passed on https://github.com/puppetlabs/puppetlabs-powershell/pull/328 

I believe that the existing protections are enough for anything except `pdk --puppet-version=` and explicit CI setups with versions between 6.0 and 6.11, which are not versions that we support in [PE versions](https://puppet.com/docs/pe/2019.8/component_versions_in_recent_pe_releases.html).

Closes #391 , which is a different, more complex approach to this, which would also require changes to the PDK.

This also obsoletes https://github.com/puppetlabs/pdk/pull/935 for now.
