### PR TITLE
Don't enforce frozen string comments

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -336,7 +336,6 @@ Rakefile:
     Style/EmptyMethod:
     Style/EvenOdd:
     Style/FormatString:
-    Style/FrozenStringLiteralComment:
     Style/HashSyntax:
     Style/InfiniteLoop:
     Style/InverseMethods:


### PR DESCRIPTION
Since Ruby 3 didn't make this the new default, we don't have to inflict
this pain on our users either.