### PR TITLE
(GH-380) Relocation of inventory.yaml file

### DIFF
--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -137,7 +137,14 @@ jobs:
         echo
         echo ::endgroup::
         echo ::group::=== INVENTORY ===
-        sed -e 's/password: .*/password: "[redacted]"/' < inventory.yaml || true
+        if [ -f 'spec/fixtures/litmus_inventory.yaml' ];
+        then
+          FILE='spec/fixtures/litmus_inventory.yaml'
+         elif [ -f 'inventory.yaml' ];
+        then
+          FILE='inventory.yaml'
+        fi
+        sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
         echo ::endgroup::
 
     - name: Install agent
@@ -172,7 +179,7 @@ jobs:
       if: ${{ always() }}
       continue-on-error: true
       run: |
-        if [ -f inventory.yaml ]; then
+        if [[ -f inventory.yaml || -f spec/fixtures/litmus_inventory.yaml ]]; then
           buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
           echo ::group::=== REQUEST ===
           cat request.json || true

--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -140,7 +140,7 @@ jobs:
         if [ -f 'spec/fixtures/litmus_inventory.yaml' ];
         then
           FILE='spec/fixtures/litmus_inventory.yaml'
-         elif [ -f 'inventory.yaml' ];
+        elif [ -f 'inventory.yaml' ];
         then
           FILE='inventory.yaml'
         fi

--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -137,7 +137,7 @@ jobs:
         if [ -f 'spec/fixtures/litmus_inventory.yaml' ];
         then
           FILE='spec/fixtures/litmus_inventory.yaml'
-         elif [ -f 'inventory.yaml' ];
+        elif [ -f 'inventory.yaml' ];
         then
           FILE='inventory.yaml'
         fi

--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -134,7 +134,14 @@ jobs:
         echo
         echo ::endgroup::
         echo ::group::=== INVENTORY ===
-        sed -e 's/password: .*/password: "[redacted]"/' < inventory.yaml || true
+        if [ -f 'spec/fixtures/litmus_inventory.yaml' ];
+        then
+          FILE='spec/fixtures/litmus_inventory.yaml'
+         elif [ -f 'inventory.yaml' ];
+        then
+          FILE='inventory.yaml'
+        fi
+        sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
         echo ::endgroup::
 
     - name: Install agent
@@ -169,7 +176,7 @@ jobs:
       if: ${{ always() }}
       continue-on-error: true
       run: |
-        if [ -f inventory.yaml ]; then
+        if [[ -f inventory.yaml || -f spec/fixtures/litmus_inventory.yaml ]]; then
           buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
           echo ::group::=== REQUEST ===
           cat request.json || true


### PR DESCRIPTION
- Renaming the inventory.yaml file to litmus_inventory.yaml
- Relocating file from the module root directory to /spec/fixtures/
- Removal of vmpooler as it is deprecated

The point in this change is to avoid running tests on a live production system by accident.

This piece of work includes changes in multiple places. 

1. pdk-templates: https://github.com/puppetlabs/pdk-templates/pull/414
2. puppet_litmus: https://github.com/puppetlabs/puppet_litmus/pull/396
3. provision module: https://github.com/puppetlabs/provision/pull/161

The follow PR is testing out my changes: https://github.com/puppetlabs/puppetlabs-testing/pull/353
