### PR TITLE
git ignore spec/fixtures/litmus_inventory.yaml

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -42,6 +42,7 @@ common:
       - '.project'
       - '.envrc'
       - '/inventory.yaml'
+      - '/spec/fixtures/litmus_inventory.yaml'
 .pdkignore:
   required: *ignorepaths
   paths:


### PR DESCRIPTION
I think the new path for inventory(`/spec/fixtures/litmus_inventory.yaml`) should also be git-ignored by default, so we don't need to add manually in `.sync.yml` file for each supported module.