### PR TITLE
Revert to using pdk 2.1.0.0 rather than nightlies

### DIFF
--- a/moduleroot/.github/workflows/release.yml.erb
+++ b/moduleroot/.github/workflows/release.yml.erb
@@ -39,10 +39,10 @@ jobs:
           ref: ${{ github.ref }}
           clean: true
       - name: "PDK Build"
-        uses: docker://puppet/pdk:nightly
+        uses: docker://puppet/pdk:2.1.0.0
         with:
           args: 'build'
       - name: "Push to Forge"
-        uses: docker://puppet/pdk:nightly
+        uses: docker://puppet/pdk:2.1.0.0
         with:
           args: 'release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force'


### PR DESCRIPTION
Currently using nightlies causes failures on the pdk build step in our auto release process. 
Issue is being tracked here: https://tickets.puppetlabs.com/browse/PDK-1714