### PR TITLE
Add changelog_max_issues configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 |changelog\_user|Sets the github user for the change_log_generator rake task. Optional, if not set it will read the `author` from the `metadata.json` file.|
 |changelog\_project|Sets the github project name for the change\_log\_generator rake task. Optional, if not set it will parse the `source` from the `metadata.json` file|
 |changelog\_since\_tag|Sets the github since_tag for the change\_log\_generator rake task. Required for the `changelog` rake task.|
+|changelog\_max\_issues|Sets the github max_issues for the change\_log\_generator rake task. Optional to limit max issues. | 
 |changelog\_version\_tag\_pattern|Template how the version tag is to be generated. Defaults to `'v%s'` which eventually align with tag\_pattern property of puppet-blacksmith, thus changelog is referring to the correct version tags and compare URLs. |
 |github_site|Override built-in default for public GitHub. Useful for GitHub Enterprise and other. (Example: `github_site = https://git.domain.tld`) |
 |github_endpoint|Override built-in default for public GitHub. Useful for GitHub Enterprise and other. (Example: `github_endpoint = https://git.domain.tld/api/v4`) |

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -92,6 +92,9 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
 <% if @configs['changelog_since_tag'] -%>
     config.since_tag = <%= @configs['changelog_since_tag'].inspect %>
 <% end -%>
+<% if @configs['changelog_max_issues'] -%>
+    config.max_issues = <%= @configs['changelog_max_issues'].inspect %>
+<% end -%>
     config.future_release = "#{changelog_future_release}"
     config.exclude_labels = ['maintenance']
     config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."


### PR DESCRIPTION
Allows setting the max_issues configuration for the github_changelog_generator tool to prevent Github API limitations for big repositories. 