### PR TITLE
(maint) Use docker pdk:nightly container

### DIFF
--- a/moduleroot/.github/workflows/release.yml.erb
+++ b/moduleroot/.github/workflows/release.yml.erb
@@ -39,10 +39,10 @@ jobs:
           ref: ${{ github.ref }}
           clean: true
       - name: "PDK Build"
-        uses: docker://puppet/pdk:2.1.0.0
+        uses: docker://puppet/pdk:nightly
         with:
           args: 'build'
       - name: "Push to Forge"
-        uses: docker://puppet/pdk:2.1.0.0
+        uses: docker://puppet/pdk:nightly
         with:
           args: 'release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force'


### PR DESCRIPTION
We had tagged to pdk:2.1.0.0 due to: https://github.com/puppetlabs/pdk/issues/1075
This has now been resolved so rolling back to use the nightlies.