### PR TITLE
Run validation steps prior to the matrix build

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -87,7 +87,7 @@ common:
     script: bundle exec rake beaker
     stage: acceptance
   includes:
-    - env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
+    - env: CHECK="validate lint check rubocop"
       stage: static
     - env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
       rvm: 2.5.7
@@ -114,7 +114,7 @@ appveyor.yml:
   use_litmus: false
   matrix:
     - RUBY_VERSION: 25-x64
-      CHECK: "syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
+      CHECK: "validate lint check rubocop"
     - PUPPET_GEM_VERSION: ~> 6.0
       RUBY_VERSION: 25
       CHECK: parallel_spec
@@ -602,12 +602,12 @@ Gemfile:
     ruby_versions:
       '2.5.7':
         checks:
-          - 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'
+          - 'validate lint check rubocop'
           - parallel_spec
         puppet_version: '~> 6'
       '2.7.2':
         checks:
-          - 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'
+          - 'validate lint check rubocop'
           - parallel_spec
         puppet_version: '~> 7'
     # beaker: true
@@ -645,6 +645,6 @@ spec/spec_helper.rb:
   unmanaged: true
 .github/workflows/spec.yml:
   unmanaged: true
-  checks: 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'
+  checks: 'validate lint check rubocop'
 .github/workflows/release.yml:
   unmanaged: true

--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -57,6 +57,11 @@ jobs:
         echo STEP_ID=Setup-Acceptance-Test-Matrix >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
 
+    - name: Run validation steps
+      run: |
+        bundle exec rake validate
+      if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+
     - name: Setup Acceptance Test Matrix
       id: get-matrix
       run: |

--- a/moduleroot/.github/workflows/spec.yml.erb
+++ b/moduleroot/.github/workflows/spec.yml.erb
@@ -61,6 +61,11 @@ jobs:
           echo STEP_ID=Setup-Acceptance-Test-Matrix >> $GITHUB_ENV
           echo STEP_START=$(date +%s) >> $GITHUB_ENV
 
+      - name: Run Static & Syntax Tests
+        if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+        run: |
+          buildevents cmd $TRACE_ID $STEP_ID 'static_syntax_checks' -- bundle exec rake <%= @configs['checks'] %>
+
       - name: Setup Spec Test Matrix
         id: get-matrix
         run: |
@@ -126,10 +131,6 @@ jobs:
           buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
           echo ::endgroup::
 
-      - name: Run Static & Syntax Tests
-        run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'static_syntax_checks Puppet ${{ matrix.puppet_version }}, Ruby ${{ matrix.ruby_version }}' -- bundle exec rake <%= @configs['checks'] %>
-      
       - name: Run parallel_spec tests
         run: |
           buildevents cmd $TRACE_ID $STEP_ID 'rake parallel_spec Puppet ${{ matrix.puppet_version }}, Ruby ${{ matrix.ruby_version }}' -- bundle exec rake parallel_spec


### PR DESCRIPTION
puppetlabs_spec_helper provides a task called validate which runs all static checks (syntax, lint, etc). If these fail, there isn't really any reason why you would want to start a full matrix build. Similarly, it also runs Rubocop prior to the matrix. Otherwise you just get a full failed matrix. The end result is less wasted CI on invalid syntax or style.

This is taken from Voxpupuli's modulesync_config.

I know this is incomplete and personally I never use PDK, but it came up in https://github.com/puppetlabs/puppetlabs_spec_helper/pull/340.