### PR TITLE
Set `skip_branch_with_pr` to true by default in appveyor.yml template

### DIFF
--- a/moduleroot/appveyor.yml.erb
+++ b/moduleroot/appveyor.yml.erb
@@ -1,5 +1,6 @@
 ---
 version: 1.1.x.{build}
+skip_branch_with_pr: true
 branches:
 <% if ((@configs['branches'] || []) - (@configs['remove_branches'] || [])).any? -%>
   only:


### PR DESCRIPTION
If the owner of a repository creates a branch, pushes it, and then creates a PR, appveyor will not build it because of the branches filter (which is currently main & release).  This used to work but i'm guessing appveyor made a breaking change and this stopped at some point.
