### PR TITLE
Only auto release if the changelog is updated

### DIFF
--- a/moduleroot/.github/workflows/auto_release.yml.erb
+++ b/moduleroot/.github/workflows/auto_release.yml.erb
@@ -56,8 +56,14 @@ jobs:
       run: |
         echo "::set-output name=ver::$(jq --raw-output .version metadata.json)"
 
-    - name: "Commit changes"
+    - name: "Check if a release is necessary"
       if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+      id: check
+      run: |
+        git diff --quiet CHANGELOG.md && echo "::set-output name=release::false" || echo "::set-output name=release::true"
+
+    - name: "Commit changes"
+      if: ${{ github.repository_owner == '<%= common['owner'] %>' && steps.check.outputs.release == 'true' }}
       run: |
         git config --local user.email "${{ github.repository_owner }}@users.noreply.github.com"
         git config --local user.name "GitHub Action"
@@ -67,7 +73,7 @@ jobs:
     - name: Create Pull Request
       id: cpr
       uses: puppetlabs/peter-evans-create-pull-request@v3
-      if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+      if: ${{ github.repository_owner == '<%= common['owner'] %>' && steps.check.outputs.release == 'true' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "Release prep v${{ steps.gv.outputs.ver }}"
@@ -83,7 +89,7 @@ jobs:
         labels: "maintenance"
 
     - name: PR outputs
-      if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
+      if: ${{ github.repository_owner == '<%= common['owner'] %>' && steps.check.outputs.release == 'true' }}
       run: |
         echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
         echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
Prior to this PR, the auto release workflow would always result in a
commit and PR. This PR updates the logic to only make the PR if the
changelog is updated.

This reduces the noise from invalid releases during the release schedule by only making PR's when there are updates to the changelog. An example of this workflow run can be seen in https://github.com/puppetlabs/puppetlabs-puppet_metrics_collector/runs/3124526271?check_suite_focus=true