### PR TITLE
Utilize the new describe_on_supported_os method

### DIFF
--- a/object_templates/class_spec.erb
+++ b/object_templates/class_spec.erb
@@ -2,12 +2,6 @@
 
 require 'spec_helper'
 
-describe '<%= name %>' do
-  on_supported_os.each do |os, os_facts|
-    context "on #{os}" do
-      let(:facts) { os_facts }
-
-      it { is_expected.to compile }
-    end
-  end
+describe_on_supported_os '<%= name %>' do
+  it { is_expected.to compile }
 end

--- a/object_templates/defined_type_spec.erb
+++ b/object_templates/defined_type_spec.erb
@@ -2,17 +2,11 @@
 
 require 'spec_helper'
 
-describe '<%= name %>' do
+describe_on_supported_os '<%= name %>' do
   let(:title) { 'namevar' }
   let(:params) do
     {}
   end
 
-  on_supported_os.each do |os, os_facts|
-    context "on #{os}" do
-      let(:facts) { os_facts }
-
-      it { is_expected.to compile }
-    end
-  end
+  it { is_expected.to compile }
 end


### PR DESCRIPTION
This demonstrates how the new describe_on_supported_os method would change the templates. This is still a draft PR to rspec-puppet-facts (https://github.com/voxpupuli/rspec-puppet-facts/pull/132) and this is to raise awareness.

I've also sent [a post](https://groups.io/g/voxpupuli/message/388) to Voxpupuli's mailing list 