### PR TITLE
Don't append a tag to image name if one already exists

### DIFF
--- a/moduleroot/.gitlab-ci.yml.erb
+++ b/moduleroot/.gitlab-ci.yml.erb
@@ -100,7 +100,11 @@ default:
 <%       else -%>
   stage: syntax
 <%       end -%>
+<%       if %r{:}.match?(image) -%>
+  image: <%= image %>
+<%       else -%>
   image: <%= image %>:<%= ruby_version %>
+<%       end -%>
   script:
     - bundle exec rake <%= check %>
   variables:


### PR DESCRIPTION
Fixes #447 