### PR TITLE
Remove env from GitHub template if all sub-keys are unset

### DIFF
--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -5,6 +5,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+<% if common['honeycomb'] or common['service_url'] %>
 env:
 <% if common['honeycomb'] -%>
   HONEYCOMB_WRITEKEY: <%= common['honeycomb']['writekey'] %>
@@ -12,6 +13,7 @@ env:
 <% end -%>
 <% if common['service_url'] -%>
   SERVICE_URL: <%= common['service_url'] %>
+<% end -%>
 <% end -%>
 
 jobs:

--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -3,6 +3,7 @@ name: "PR Testing"
 
 on: [pull_request]
 
+<% if common['honeycomb'] or common['service_url'] %>
 env:
 <% if common['honeycomb'] -%>
   HONEYCOMB_WRITEKEY: <%= common['honeycomb']['writekey'] %>
@@ -10,6 +11,7 @@ env:
 <% end -%>
 <% if common['service_url'] -%>
   SERVICE_URL: <%= common['service_url'] %>
+<% end -%>
 <% end -%>
 
 jobs:

--- a/moduleroot/.github/workflows/spec.yml.erb
+++ b/moduleroot/.github/workflows/spec.yml.erb
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
   pull_request:
 
+<% if common['honeycomb'] or common['service_url'] %>
 env:
 <% if common['honeycomb'] -%>
   HONEYCOMB_WRITEKEY: <%= common['honeycomb']['writekey'] %>
@@ -14,6 +15,7 @@ env:
 <% end -%>
 <% if common['service_url'] -%>
   SERVICE_URL: <%= common['service_url'] %>
+<% end -%>
 <% end -%>
 
 jobs:


### PR DESCRIPTION
This PR resolves #448 by removing the empty `env` key from GitHub Actions templates if neither of the sub-keys are set. More details can be found on #448.