### PR TITLE
(maint) - Update lint exclusion

### DIFF
--- a/moduleroot/.puppet-lint.rc.erb
+++ b/moduleroot/.puppet-lint.rc.erb
@@ -29,5 +29,5 @@
 --<%= option %>
 <% end -%>
 <% if exclusions -%>
---ignore-paths=<%= exclusions.join(',') %>
+--ignore-paths=vendor/**/*.pp,bundle/**/*.pp,pkg/**/*.pp,spec/**/*.pp,tests/**/*.pp,types/**/*.pp,<%= exclusions.join(',') %>
 <% end -%>

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -75,7 +75,7 @@ PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('<%= option %>')
 <% end -%>
 <% if @configs['linter_exclusions'] -%>
-PuppetLint.configuration.ignore_paths = <%= @configs['linter_exclusions']%>
+PuppetLint.configuration.ignore_paths += <%= @configs['linter_exclusions']%>
 <% end -%>
 
 


### PR DESCRIPTION
As is when a linter_exclusion is passed it overwrites the current values instead of adding to them. This changes let's the ocnfiguration value be updated rather than overwritten and adds the default values to the puppet-lint.rc