### PR TITLE
(GH-327) Fix rubocop "off" & "hardcore" profiles

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -402,7 +402,7 @@ Rakefile:
 
   profiles:
     # no rubocops enabled, caveat emptor!
-    "off":
+    off:
       enabled_cops: {}
 
     # a sanitized list of cops that'll cleanup a code base without much effort

--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -62,12 +62,12 @@ default_pending_cops = config_defaults[:default_pending_cops] || []
 
 cop_configs = (profile['enabled_cops'] || {})
 
-if enabled_cops == 'all'
-  enabled_cops = default_enabled_cops
+if cop_configs == 'all'
+  enabled_cops = default_enabled_cops + default_pending_cops
 elsif cop_configs.respond_to?(:keys)
   enabled_cops = cop_configs.keys
 else
-  enabled_cops = {}
+  enabled_cops = []
 end
 
 (enabled_cops & default_enabled_cops).sort.each { |c| configs[c] ||= cop_configs[c] if cop_configs[c] }


### PR DESCRIPTION
- Quoting the off hash key changed its value.
- enabled_cops conditional is always wrong because it isn't set yet
- hardcore should imply the kitchen sink, hence pending cops, too
- enabled cops is an array, not a hash.