### PR TITLE
(MODULES-11220) Disable nightly workflows on forks

### DIFF
--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -18,6 +18,7 @@ env:
 
 jobs:
   setup_matrix:
+    if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
     name: "Setup Test Matrix"
     runs-on: ubuntu-20.04
     outputs:
@@ -197,7 +198,7 @@ jobs:
 
 <% if @configs['slack-notifications'] -%>
   slack-workflow-status:
-    if: always()
+    if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
     name: Post Workflow Status To Slack
     needs:
       - Acceptance


### PR DESCRIPTION
Although Github Actions are disabled on forks, a user can still manually enable them and encounter errors like that reported in [MODULES-11220](https://tickets.puppetlabs.com/browse/MODULES-11220).

This commit adds an `if` guard for the `Setup Test Matrix` and `slack-workflow-status` job and step, respectively