### PR TITLE
Add a knob to allow tasks testing using ruby_task_helper

### DIFF
--- a/moduleroot/.github/workflows/spec.yml.erb
+++ b/moduleroot/.github/workflows/spec.yml.erb
@@ -134,6 +134,12 @@ jobs:
           buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
           echo ::endgroup::
 
+<% if @configs['use_ruby_task_helper'] -%>
+      - name: Create task helper symlink
+        run: |
+          ln -s "${PWD}/spec/fixtures/modules/ruby_task_helper" ..
+<% end -%>
+
       - name: Run parallel_spec tests
         run: |
           buildevents cmd $TRACE_ID $STEP_ID 'rake parallel_spec Puppet ${{ matrix.puppet_version }}, Ruby ${{ matrix.ruby_version }}' -- bundle exec rake parallel_spec


### PR DESCRIPTION
The puppetlabs/ruby_task_helper module provide helpers to write testable
bolt tasks.  For this to work, the tested module depends on a copy of the
ruby_task_helper module to be beside it: quoting ruby_task_helper's
documentation:

> Make sure the task helper repo is checked out next to your module so
> the relative requires work and you can write simple unit tests for the
> methods of your task.

This commit test for a `use_ruby_task_helper` setting to create a
symlink before running the test suite.  This link points to the fixture
directory where the appropriate version of ruby_task_helper will be
put according to what the `.fixtures.yml` file says in the module under
test.
