### PR TITLE
Use voxpupuli-puppet-lint-plugins

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -584,6 +584,9 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
+      - gem: 'voxpupuli-puppet-lint-plugins'
+        platforms: ruby
+        version: '>= 3.0'
     ':system_tests':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         version: '~> 1.0'


### PR DESCRIPTION
This is a collection of puppet-lint plugins that reflect the current
community standards. Version 3 of the gem includes:
* puppet-lint-absolute_classname-check
* puppet-lint-anchor-check
* puppet-lint-classes_and_types_beginning_with_digits-check
* puppet-lint-file_ensure-check
* puppet-lint-leading_zero-check
* puppet-lint-legacy_facts-check
* puppet-lint-lookup_in_parameter-check
* puppet-lint-manifest_whitespace-check
* puppet-lint-optional_default-check
* puppet-lint-param-docs
* puppet-lint-params_empty_string-check
* puppet-lint-param-types
* puppet-lint-resource_reference_syntax
* puppet-lint-strict_indent-check
* puppet-lint-top_scope_facts-check
* puppet-lint-topscope-variable-check
* puppet-lint-trailing_comma-check
* puppet-lint-unquoted_string-check
* puppet-lint-variable_contains_upcase
* puppet-lint-version_comparison-check