### PR TITLE
puppet-lint: fail on warnings

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -128,6 +128,7 @@ appveyor.yml:
     - main
     - release
 Rakefile:
+  linter_fail_on_warnings: true
   changelog_version_tag_pattern: 'v%s'
   default_disabled_lint_checks:
     - 'relative'


### PR DESCRIPTION
It's the current community best practice to actually honour the
puppet-lint warnings and fail during CI. pdk should reflect that as
well.