### PR TITLE
Enable puppet coverage reports

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -629,7 +629,7 @@ spec/default_facts.yml:
   is_pe: false
   macaddress: "AA:AA:AA:AA:AA:AA"
 spec/spec_helper.rb:
-  coverage_report: false
+  coverage_report: true
   minimum_code_coverage_percentage: 0
   mock_with: ":rspec"
   strict_level: ":warning"


### PR DESCRIPTION
Those are required to ensure a certain level of coverage and it's the
current community best practice to have those reports enables. pdk
should reflect that.