### PR TITLE
Update TargetrubyVersion for rubocop

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -7,7 +7,7 @@ defaults = {
   ],
   'AllCops' => {
     'DisplayCopNames' => true,
-    'TargetRubyVersion' => '2.4',
+    'TargetRubyVersion' => '2.5',
     'Include' => [
       '**/*.rb',
     ],


### PR DESCRIPTION
Prior to this commit the main template tested ruby syntax against ruby version 2.4
Since in the lowest Support release of Puppet, Ruby version 2.5 is in use, this is no longer the sensible default.


Defaulting to 2.5 ensures that code is linted to the most compatible ruby version for supported Puppet releases
