### PR TITLE
(maint) Update default slack channel

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -641,7 +641,7 @@ spec/spec_helper.rb:
 .github/workflows/nightly.yml:
   unmanaged: true
   slack-notifications:
-    channel: '#team-ia-bots'
+    channel: '#team-cat-bots'
     name: 'GABot'
 .github/workflows/pr_test.yml:
   unmanaged: true


### PR DESCRIPTION
Due to IAC being renamed to CAT the channel set here needs to be changed