### PR TITLE
Disable Travis by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ In this example the automated release prep workflow is triggered every Saturday 
 We can trigger automated builds with every change to our code base in the main branch, other branches or even a pull request.
 Travis uses a .travis.yml file in the root of your repository to learn about your project and how you want your builds to be executed.
 
+To enable adding the .travis.yml file, add this key to your `.sync.yml`:
+
+``` yaml
+.travis.yml:
+  unmanaged: false
+```
+
 | Key            | Description   |
 | :------------- |:--------------|
 | os | Set to an array of operating systems to test. See the [TravisCI documentation](https://docs.travis-ci.com/user/multi-os/) for more details. |

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -69,6 +69,7 @@ common:
     - '/.sync.yml'
     - '/.devcontainer/'
 .travis.yml:
+  unmanaged: true
   stages:
     - static
     - spec


### PR DESCRIPTION
Given that Travis no longer has a usable free tier and the recent
security vulnerabilities, I'd like to open the conversation about
disabling it by default.

Setting the file to `unmanaged` means that this will only affect new
modules--it will not delete existing configurations from modules
currently using it. Users can easily enable it by just setting the one
key and all the existing default configuration is used.