### PR TITLE
allow to configure rspec-puppet's facter_implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Travis uses a .travis.yml file in the root of your repository to learn about you
 | Key            | Description   |
 | :------------- |:--------------|
 |default_facter_version|Sets the [`default_facter_version`](https://github.com/mcanevet/rspec-puppet-facts#specifying-a-default-facter-version) rspec-puppet-facts parameter.|
+|facter_implementation|Sets the [`facter_implementation`](https://github.com/puppetlabs/rspec-puppet#facter_implementation) rspec-puppet parameter. Current available options are `rspec` and `facter`, with `facter` being the default. The `rspec` implementation offers a significant performance improvement and results in faster unit tests.|
 |hiera_config|Sets the [`hiera_config`](http://rspec-puppet.com/documentation/configuration/#hiera_config) rspec-puppet parameter.|
 |hiera_config_ruby|Sets the [`hiera_config`](http://rspec-puppet.com/documentation/configuration/#hiera_config) rspec-puppet parameter. A ruby expression returning the path to your hiera.yaml file. `hiera_config` takes precedence if both values `hiera_config` and `hiera_config_ruby` are specified. |
 |mock_with|Defaults to `':rspec'`. If you need the previous default of "some mocha and some rspec-mocks", set `mock_with: ~` (tilde symbol, the YAML null value).|

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -43,6 +43,9 @@ RSpec.configure do |c|
   <%- if @configs['default_facter_version'] -%>
   c.default_facter_version = '<%= @configs['default_facter_version'] %>'
   <%- end -%>
+  <%- if @configs['facter_implementation'] -%>
+  c.facter_implementation = <%= @configs['facter_implementation'] %>
+  <%- end -%>
   <%- if @configs['hiera_config'] -%>
   c.hiera_config = '<%= @configs['hiera_config'] %>'
   <%- elsif @configs['hiera_config_ruby'] -%>


### PR DESCRIPTION
Reading [this article](https://dev.to/puppet/faster-module-tests-with-facter-4-and-rspec-puppet-561e) made me want to try the setting out. My CI job went from 5min40s to 2min37s so I was easily sold. This PR makes it possible to configure it through PDK templates.