### PR TITLE
Create changelog if needed

### DIFF
--- a/moduleroot/.github/workflows/auto_release.yml.erb
+++ b/moduleroot/.github/workflows/auto_release.yml.erb
@@ -44,6 +44,10 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
+    - name: "Migrate history if needed"
+      run: |
+        if test -f HISTORY.md && ! test -f CHANGELOG.md; then touch CHANGELOG.md; git add CHANGELOG.md; git commit CHANGELOG.md -m 'Creating changelog'; fi
+
     - name: "PDK Release prep"
       uses: docker://puppet/iac_release:ci
       with:


### PR DESCRIPTION
When migrating to gh-changelog-generator, you move your existing
changelog to HISTORY.md and then the generator appends that to the end
of the new CHANGELOG.md file.

However, when this workflow runs, it uses `git diff` to identify changes
in the CHANGELOG.md file, and creation of a new file are not flagged.
The simplest way to make that check work is to create an empty file to
compare against. This should only take effect on the very first release
when HISTORY.md exists, but the new CHANGELOG.md does not.
