### PR TITLE
(CONT-19) Removal of puppet-module-gems

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -557,32 +557,39 @@ Gemfile:
   required:
     ':development':
       - gem: 'json'
+        version: '~> 2.0'
       - gem: 'voxpupuli-puppet-lint-plugins'
-        version: '>= 3.0.0'
+        version: '~> 3.0'
       - gem: 'facterdb'
-        version: '< 2.0.0'
+        version: '~> 1.18'
       - gem: 'metadata-json-lint'
-        version: '< 4.0.0'
-      - gem: 'puppet-lint'
-        version: '< 3.0.0'
+        version:
+        - '>= 2.0.2'
+        - '< 4.0.0'
       - gem: 'puppetlabs_spec_helper'
-        version: '< 4.0.0'
-      - gem: 'rspec-puppet'
-        version: '< 3.0.0'
+        version:
+        - '>= 3.0.0'
+        - '< 5.0.0'
       - gem: 'rspec-puppet-facts'
-        version: '< 3.0.0'
+        version: '~> 2.0'
       - gem: 'codecov'
+        version: '~> 0.2'
       - gem: 'dependency_checker'
+        version: '~> 0.2'
       - gem: 'parallel_tests'
+        version: '~> 3.4'
       - gem: 'pry'
-      - gem: 'serverspec'
+        version: '~> 0.10'
       - gem: 'simplecov-console'
-      - gem: 'specinfra'
+        version: '~> 0.5'
       - gem: 'puppet-debugger'
-      - gem: 'ed25519'
-        platforms: ruby
-      - gem: 'bcrypt_pbkdf'
-        platforms: ruby
+        version: '~> 1.0'
+      - gem: 'rubocop'
+        version: '= 1.6.1'
+      - gem: 'rubocop-performance'
+        version: '= 1.9.1'
+      - gem: 'rubocop-rspec'
+        version: '= 2.0.1'
       - gem: 'rb-readline'
         version: '= 0.5.5'
         platforms:
@@ -593,6 +600,8 @@ Gemfile:
       - gem: 'puppet_litmus'
         version: '< 1.0.0'
         platforms: ruby
+      - gem: 'serverspec'
+        version: '~> 2.41'
 .gitlab-ci.yml:
   defaults:
     cache:

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -556,46 +556,43 @@ Rakefile:
 Gemfile:
   required:
     ':development':
-      # hardcode JSON version to what's shipped in pdk for now
-      - gem: json
-        version: '= 2.0.4'
-        condition: "Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
-      - gem: json
-        version: '= 2.1.0'
-        condition: "Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
-      - gem: json
-        version: '= 2.3.0'
-        condition: "Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
-      - gem: 'puppet-module-posix-default-r#{minor_version}'
-        version: '~> 1.0'
-        platforms: ruby
-      - gem: 'puppet-module-posix-dev-r#{minor_version}'
-        version: '~> 1.0'
-        platforms: ruby
-      - gem: 'puppet-module-win-default-r#{minor_version}'
-        version: '~> 1.0'
-        platforms:
-          - mswin
-          - mingw
-          - x64_mingw
-      - gem: 'puppet-module-win-dev-r#{minor_version}'
-        version: '~> 1.0'
-        platforms:
-          - mswin
-          - mingw
-          - x64_mingw
+      - gem: 'json'
       - gem: 'voxpupuli-puppet-lint-plugins'
-        version: '>= 3.0'
-    ':system_tests':
-      - gem: 'puppet-module-posix-system-r#{minor_version}'
-        version: '~> 1.0'
+        version: '>= 3.0.0'
+      - gem: 'facterdb'
+        version: '< 2.0.0'
+      - gem: 'metadata-json-lint'
+        version: '< 4.0.0'
+      - gem: 'puppet-lint'
+        version: '< 3.0.0'
+      - gem: 'puppetlabs_spec_helper'
+        version: '< 4.0.0'
+      - gem: 'rspec-puppet'
+        version: '< 3.0.0'
+      - gem: 'rspec-puppet-facts'
+        version: '< 3.0.0'
+      - gem: 'codecov'
+      - gem: 'dependency_checker'
+      - gem: 'parallel_tests'
+      - gem: 'pry'
+      - gem: 'serverspec'
+      - gem: 'simplecov-console'
+      - gem: 'specinfra'
+      - gem: 'puppet-debugger'
+      - gem: 'ed25519'
         platforms: ruby
-      - gem: 'puppet-module-win-system-r#{minor_version}'
-        version: '~> 1.0'
+      - gem: 'bcrypt_pbkdf'
+        platforms: ruby
+      - gem: 'rb-readline'
+        version: '= 0.5.5'
         platforms:
           - mswin
           - mingw
           - x64_mingw
+    ':system_tests':
+      - gem: 'puppet_litmus'
+        version: '< 1.0.0'
+        platforms: ruby
 .gitlab-ci.yml:
   defaults:
     cache:

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -1,11 +1,20 @@
 <%
 def gem_length(gem)
-  if gem['from_env']
-    version_len = " *location_for(ENV['#{gem['from_env']}'])".length + ((" || '#{gem['version']}'".length if gem['version']) || 0)
-  else
-    version_len = (", '#{gem['version']}'".length if gem['version']) || 0
-  end
+  if gem['version']
+    gem_output = ''
+    Array(gem['version']).each do |version|
+      gem_output += " '#{version}',"
+    end
+    gem_output = gem_output.chomp(',')
 
+    if gem['from_env']
+      version_len = " *location_for(ENV['#{gem['from_env']}'])".length + " ||#{gem_output}".length
+    else
+      version_len = ",#{gem_output}".length
+    end
+  else
+    version_len = 0
+  end
   gem['gem'].length + version_len
 end
 
@@ -13,10 +22,17 @@ def gem_spec(gem, max_len)
   output = "\"#{gem['gem']}\""
 
   if gem['version']
+    gem_output = ''
+    # For each version requirement given add to the string and place a `,`
+    Array(gem['version']).each do |version|
+      gem_output += " '#{version}',"
+    end
+    gem_output = gem_output.chomp(',')
+
     if gem['from_env']
-      output += ", *location_for(ENV['#{gem['from_env']}'] || '#{gem['version']}')"
+      output += ", *location_for(ENV['#{gem['from_env']}'] ||#{gem_output})"
     else
-      output += ", '#{gem['version']}'"
+      output += ",#{gem_output}"
     end
   end
 

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -71,9 +71,6 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
-ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = ruby_version_segments[0..1].join('.')
-
 <%
   groups = {}
   (@configs['required'].keys + ((@configs['optional'] || {}).keys)).uniq.each do |key|


### PR DESCRIPTION
With the recent updates to bundler the need for a specific set off gems for each version of ruby that we support has been removed.
As such the logic behind our gems is now much simpler and can easily fit within the default templates, thus removing our need to have a separate module to manage them, with the templates already managing all other similar default requirements for our modules.