### PR TITLE
(maint) Exclusion added against Json version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 os: linux
-dist: xenial
+dist: focal
 language: generic
 env:
   - PDK=release PDK_FRONTEND=noninteractive

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -557,7 +557,9 @@ Gemfile:
   required:
     ':development':
       - gem: 'json'
-        version: '~> 2.0'
+        version:
+        - '~> 2.0'
+        - '!= 2.6.2'
       - gem: 'voxpupuli-puppet-lint-plugins'
         version: '~> 3.0'
       - gem: 'facterdb'


### PR DESCRIPTION
The Json version 2.6.2 causes issues for our Windows machines and so we are setting an exclusion against it.