### PR TITLE
voxpupuli-puppet-lint-plugins: Pull in 3.1 or newer

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -561,7 +561,7 @@ Gemfile:
         - '~> 2.0'
         - '!= 2.6.2'
       - gem: 'voxpupuli-puppet-lint-plugins'
-        version: '~> 3.0'
+        version: '~> 3.1'
       - gem: 'facterdb'
         version: '~> 1.18'
       - gem: 'metadata-json-lint'


### PR DESCRIPTION
We released Version 3.1 today. It pulls in latest versions of the different plugins. This is basically a bugfix because we noticed that pdk doesn't automatically update available gems. With this simple change, the version in the Gemfile will be raised and pdk will ensure latest versions are installed, without the requirement of people running `pdk bundle update` (which could have sideeffects).