### PR TITLE
(CONT-380) Bump voxpupuli-puppet-lint-plugins

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -585,7 +585,7 @@ Gemfile:
           - mingw
           - x64_mingw
       - gem: 'voxpupuli-puppet-lint-plugins'
-        version: '>= 3.0'
+        version: '~> 3.1'
     ':system_tests':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         version: '~> 1.0'


### PR DESCRIPTION
Prior to this commit the gem configuration would not pull in newer versions of the puppet lint plugin.

This commit back ports a change made in
bdcddb1dcdb16f0ff57239fb33e2012756fee8b9 to pull in version 3.1 or newer.