### PR TITLE
(MAINT) Replacing json with json_pure

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -556,10 +556,9 @@ Rakefile:
 Gemfile:
   required:
     ':development':
-      - gem: 'json'
+      - gem: 'json_pure'
         version:
         - '~> 2.0'
-        - '!= 2.6.2'
       - gem: 'voxpupuli-puppet-lint-plugins'
         version: '~> 3.1'
       - gem: 'facterdb'


### PR DESCRIPTION
Prior to this commit all modules have been consuming the JSON gem. This is causing issues with Windows Support. 

This change aims to resolve the issues and simplify gem and native extensions being used.