### PR TITLE
Ensure that the devcontainer.json is valid JSON

### DIFF
--- a/moduleroot/.devcontainer/devcontainer.json
+++ b/moduleroot/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"settings": {
 		"terminal.integrated.profiles.linux": {
 			"bash": {
-				"path": "bash",
+				"path": "bash"
 			}
 		}
 	},


### PR DESCRIPTION
Currently, the devcontainer.json template file is invalid JSON resulting in a failed JSON parser error if people have a JSON parser in their CI/CD pipeline. Fixing this to avoid this issue moving forward when updating or creating a module with PDK.