### PR TITLE
(MAINT) Update pdk release image

### DIFF
--- a/moduleroot/.github/workflows/auto_release.yml.erb
+++ b/moduleroot/.github/workflows/auto_release.yml.erb
@@ -45,7 +45,7 @@ jobs:
         persist-credentials: false
 
     - name: "PDK Release prep"
-      uses: docker://puppet/iac_release:ci
+      uses: docker://puppet/pdk:2.6.1.0
       with:
         args: 'release prep --force'
       env:


### PR DESCRIPTION
Prior to this commit the PDK release image used was tagged with ci.

This commit updates the release prep container to use the latest version of the PDK.