### PR TITLE
(maint) Updates checkout action

### DIFF
--- a/moduleroot/.github/workflows/auto_release.yml.erb
+++ b/moduleroot/.github/workflows/auto_release.yml.erb
@@ -39,7 +39,7 @@ jobs:
 <% end -%>
     - name: "Checkout Source"
       if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
         persist-credentials: false

--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -39,7 +39,7 @@ jobs:
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
 <% end -%>
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
 
     - name: Activate Ruby 2.7
@@ -112,7 +112,7 @@ jobs:
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
 
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1

--- a/moduleroot/.github/workflows/pr_test.yml.erb
+++ b/moduleroot/.github/workflows/pr_test.yml.erb
@@ -36,7 +36,7 @@ jobs:
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
 <% end -%>
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
 
     - name: Activate Ruby 2.7
@@ -113,7 +113,7 @@ jobs:
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
 <% end -%>
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1

--- a/moduleroot/.github/workflows/release.yml.erb
+++ b/moduleroot/.github/workflows/release.yml.erb
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           clean: true
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           clean: true

--- a/moduleroot/.github/workflows/spec.yml.erb
+++ b/moduleroot/.github/workflows/spec.yml.erb
@@ -40,7 +40,7 @@ jobs:
           echo STEP_START=$(date +%s) >> $GITHUB_ENV
 <% end -%>
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         if: ${{ github.repository_owner == '<%= common['owner'] %>' }}
 
       - name: Activate Ruby 2.7
@@ -120,7 +120,7 @@ jobs:
           matrix-key: ${{ env.SANITIZED_PUPPET_VERSION }}
 <% end -%>
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Activate Ruby ${{ matrix.ruby_version }}"
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This commit updates all instances of the actions/checkout@v2 to actions/checkout@v3 in perparation for the former's deprecation as part of the NodeJS deprecation.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/