### PR TITLE
Update Gitpod Dockerfile

### DIFF
--- a/moduleroot/.gitpod.Dockerfile
+++ b/moduleroot/.gitpod.Dockerfile
@@ -1,8 +1,8 @@
 FROM gitpod/workspace-full
-RUN sudo wget https://apt.puppet.com/puppet-tools-release-bionic.deb && \
-    wget https://apt.puppetlabs.com/puppet6-release-bionic.deb && \
-    sudo dpkg -i puppet6-release-bionic.deb && \
-    sudo dpkg -i puppet-tools-release-bionic.deb && \
+RUN sudo wget https://apt.puppet.com/puppet-tools-release-focal.deb && \
+    wget https://apt.puppetlabs.com/puppet6-release-focal.deb && \
+    sudo dpkg -i puppet6-release-focal.deb && \
+    sudo dpkg -i puppet-tools-release-focal.deb && \
     sudo apt-get update && \
     sudo apt-get install -y pdk zsh puppet-agent && \
     sudo apt-get clean && \
@@ -14,5 +14,5 @@ RUN sudo usermod -s $(which zsh) gitpod && \
     sudo /opt/puppetlabs/puppet/bin/gem install puppet-debugger hub -N && \
     mkdir -p /home/gitpod/.config/puppet && \
     /opt/puppetlabs/puppet/bin/ruby -r yaml -e "puts ({'disabled' => true}).to_yaml" > /home/gitpod/.config/puppet/analytics.yml
-RUN rm -f puppet6-release-bionic.deb  puppet-tools-release-bionic.deb
+RUN rm -f puppet6-release-focal.deb  puppet-tools-release-focal.deb
 ENTRYPOINT /usr/bin/zsh

--- a/moduleroot/.gitpod.Dockerfile
+++ b/moduleroot/.gitpod.Dockerfile
@@ -3,6 +3,7 @@ RUN sudo wget https://apt.puppet.com/puppet-tools-release-focal.deb && \
     wget https://apt.puppetlabs.com/puppet6-release-focal.deb && \
     sudo dpkg -i puppet6-release-focal.deb && \
     sudo dpkg -i puppet-tools-release-focal.deb && \
+    rm -f puppet6-release-focal.deb  puppet-tools-release-focal.deb && \
     sudo apt-get update && \
     sudo apt-get install -y pdk zsh puppet-agent && \
     sudo apt-get clean && \
@@ -14,5 +15,4 @@ RUN sudo usermod -s $(which zsh) gitpod && \
     sudo /opt/puppetlabs/puppet/bin/gem install puppet-debugger hub -N && \
     mkdir -p /home/gitpod/.config/puppet && \
     /opt/puppetlabs/puppet/bin/ruby -r yaml -e "puts ({'disabled' => true}).to_yaml" > /home/gitpod/.config/puppet/analytics.yml
-RUN rm -f puppet6-release-focal.deb  puppet-tools-release-focal.deb
 ENTRYPOINT /usr/bin/zsh

--- a/moduleroot/.gitpod.Dockerfile
+++ b/moduleroot/.gitpod.Dockerfile
@@ -1,9 +1,9 @@
 FROM gitpod/workspace-full
 RUN sudo wget https://apt.puppet.com/puppet-tools-release-focal.deb && \
-    wget https://apt.puppetlabs.com/puppet6-release-focal.deb && \
-    sudo dpkg -i puppet6-release-focal.deb && \
+    wget https://apt.puppetlabs.com/puppet7-release-focal.deb && \
+    sudo dpkg -i puppet7-release-focal.deb && \
     sudo dpkg -i puppet-tools-release-focal.deb && \
-    rm -f puppet6-release-focal.deb  puppet-tools-release-focal.deb && \
+    rm -f puppet7-release-focal.deb  puppet-tools-release-focal.deb && \
     sudo apt-get update && \
     sudo apt-get install -y pdk zsh puppet-agent && \
     sudo apt-get clean && \


### PR DESCRIPTION
- Improve Docker Layering (remove temporary file in the same layer they are downloaded)
- workspace-full Container base image has been updated to Ubuntu focal, so update puppet release to focal too.
- Update to Puppet 7
  - Building fails with Puppet 6 as latest version of puppet-debugger cannot be installed anymore with it (see below)

```
ERROR:  Error installing puppet-debugger:
        The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.3.26. Try installing it with `gem install bundler -v 2.3.26` and then running the current command again
        bundler requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.
```