### PR TITLE
Add x64_mingw support for puppet_litmus

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -614,7 +614,9 @@ Gemfile:
     ':system_tests':
       - gem: 'puppet_litmus'
         version: '< 1.0.0'
-        platforms: ruby
+        platforms: 
+          - ruby
+          - x64_mingw
       - gem: 'serverspec'
         version: '~> 2.41'
 .gitlab-ci.yml:


### PR DESCRIPTION
This had previously been removed during the migration away from puppet_module_gems.

This commit re-adds the platform support for x64_mingw.