### PR TITLE
(CONT-705) Pin parallel_tests gem

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -591,7 +591,7 @@ Gemfile:
       - gem: 'dependency_checker'
         version: '~> 0.2'
       - gem: 'parallel_tests'
-        version: '~> 3.4'
+        version: '= 3.12.1'
       - gem: 'pry'
         version: '~> 0.10'
       - gem: 'simplecov-console'


### PR DESCRIPTION
This PR pins parallel_tests to 3.12.1 which is the last version that supports ruby 2.5.9.

The change is being implemented to prevent conflicts when building moduiles on older rubies.