### PR TITLE
(GH-501) Remove legacy facts gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ The following is a description and explanation of each of the keys within config
 
 | Key                    | Description |
 |:-----------------------|:------------|
-| disable\_legacy\_facts | Set to `true` to configure PDK to prevent the use of [legacy Facter facts][legacy_facts_doc]. Currently this will install and enable the [legacy\_facts][legacy_facts_pl_plugin] plugin for puppet-lint for use during `pdk validate`. |
 | honeycomb | While enabled by default, honeycomb's use can be turned off: `enabled: false` |
 
 ### .editorconfig
@@ -342,7 +341,6 @@ Gemfile:
 Please note that the early version of this template contained only a 'moduleroot' directory, and did not have a 'moduleroot\_init'. The PDK 'pdk new module' command will still work with templates that only have 'moduleroot', however the 'pdk convert' command will fail if the template does not have a 'moduleroot_init' directory present. To remedy this please use the up to date version of the template.
 
 [legacy_facts_doc]: https://puppet.com/docs/facter/latest/core_facts.html#legacy-facts
-[legacy_facts_pl_plugin]: https://github.com/mmckinst/puppet-lint-legacy_facts-check
 
 ## Security Considerations on Github Actions
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,6 +1,5 @@
 ---
 common:
-  disable_legacy_facts: false
   owner: puppetlabs
   honeycomb:
     enabled: true

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -76,16 +76,6 @@ end
   (@configs['required'].keys + ((@configs['optional'] || {}).keys)).uniq.each do |key|
     groups[key] = (@configs['required'][key] || []) + ((@configs['optional'] || {})[key] || [])
   end
-
-  if respond_to?(:config_for)
-    common_config = config_for('common')
-
-    if common_config['disable_legacy_facts']
-      groups[':development'] << {
-        'gem' => 'puppet-lint-legacy_facts-check',
-      }
-    end
-  end
 -%>
 <% groups.each do |group, gems| -%>
 group <%= group %> do


### PR DESCRIPTION
This change removes the template logic that adds
`puppet-lint_legacy_facts-checl` based on `common:disable_legacy_facts` config and fixes #501.

The legacy facts check is now part of puppet-lint which means including this gem is no longer required.

Additionally, users that currently have `disable_legacy_facts` set to `true` in their `.sync` file may encounter breaking dependency conflicts.