### PR TITLE
Remove puppet-blacksmith requirement

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -15,7 +15,6 @@ require 'bundler'
 require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
-require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
 require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
 require 'puppet-strings/tasks' if Bundler.rubygems.find_name('puppet-strings').any?
 <% if ! @configs['requires'].nil? -%>


### PR DESCRIPTION
Prior to this commit puppet-blacksmith or a version of puppet-module-gems with this gem pulled into it was required to run any local PDK rake tasks, including litmus, this gem is not used by default anywhere and should not be part of the template