### PR TITLE
(maint) - Update fixtures/modules path for .gitignore

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -28,7 +28,7 @@ common:
     - '/log/'
     - '/pkg/'
     - '/spec/fixtures/manifests/'
-    - '/spec/fixtures/modules/'
+    - '/spec/fixtures/modules/*'
     - '/tmp/'
     - '/vendor/'
     - '/convert_report.txt'


### PR DESCRIPTION
Prior to this PR, the path supplied to .gitignore for `spec/fixtures/modules/` did not allow for manual unsetting of .gitignore for subdirectories, which caused the check:gitignore check to fail and throw "File specified in .gitignore has been committed"

To give more context, take the puppetlabs-node_encrypt module. The node_encrypt module defines a module called "redact" within `spec/fixtures/modules/redact/`, and this is required for the testing of the module. However, once the `bundle exec rake syntax lint check:git_ignore` command is run, we get the error seen above.

This PR alters the required path added to the .gitignore of modules, but does not alter its core behaviour. (**it will still ignore all files under /spec/fixtures/modules**), however now we can pass additional paths to exclude subdirectories from .gitignore (i.e. spec/fixtures/modules/redact/) in our .sync.yml.