### PR TITLE
(CONT-1119) Add puppet-strings

### DIFF
--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -1,0 +1,27 @@
+name: Labeller
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+  pull_request_target:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: puppetlabs/community-labeller@v1.0.1
+        name: Label issues or pull requests
+        with:
+          label_name: community
+          label_color: '5319e7'
+          org_membership: puppetlabs
+          fail_if_member: 'true'
+          token: ${{ secrets.IAC_COMMUNITY_LABELER }}

--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ In this example the automated release prep workflow is triggered every Saturday 
 ```yaml
 ---
 networking:
-    ip: "172.16.254.254"
-    ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
-    mac: "AA:AA:AA:AA:AA:AA"
+  ip: "172.16.254.254"
+  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+  mac: "AA:AA:AA:AA:AA:AA"
 is_pe: false
 ```
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -536,6 +536,8 @@ Gemfile:
         version: '= 1.16.0'
       - gem: 'rubocop-rspec'
         version: '= 2.19.0'
+      - gem: 'puppet-strings'
+        version: '~> 3.0'
       - gem: 'rb-readline'
         version: '= 0.5.5'
         platforms:

--- a/moduleroot/spec/default_facts.yml.erb
+++ b/moduleroot/spec/default_facts.yml.erb
@@ -1,3 +1,4 @@
+<% require 'yaml' -%>
 # Use default_module_facts.yml for module specific facts.
 #
 # Facts specified here will override the values provided by rspec-puppet-facts.
@@ -6,9 +7,13 @@ networking:
   ip: "<%= @configs['networking']['ip'] %>"
   ip6: "<%= @configs['networking']['ip6'] %>"
   mac: "<%= @configs['networking']['mac'] %>"
-
+<% if @configs.dig('extra_facts', 'networking') -%>
+<% @configs['extra_facts']['networking'].each do |k, v| -%>
+  <%=k%>: "<%= v %>"
+<% end -%>
+<% @configs['extra_facts'].delete('networking') -%>
+<% end -%>
 is_pe: <%= @configs['is_pe'] %>
-<% if !@configs['extra_facts'].nil? -%>
-<% require 'yaml' -%>
+<% if @configs.dig('extra_facts') && !@configs['extra_facts'].empty? -%>
 <%= @configs['extra_facts'].to_yaml[4..-1] %>
 <% end -%>

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -27,7 +27,7 @@ default_fact_files.each do |f|
   next unless File.exist?(f) && File.readable?(f) && File.size?(f)
 
   begin
-    default_facts.deep_merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
+    default_facts.merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end


### PR DESCRIPTION
## Summary
This PR adds puppet-strings to the default template Gemfile.

## Additional Context
Requires the following PR to be merged: https://github.com/puppetlabs/bolt/pull/3216

## Related Issues (if any)
PDK is unable to pull in newer versions of puppet-strings because of a dependency in bolt. We should also reference puppet-strings as a first party gem in module Gemfiles.