### PR TITLE
(CONT-1229) - Allow nested extra networking facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ In this example the automated release prep workflow is triggered every Saturday 
 ```yaml
 ---
 networking:
-    ip: "172.16.254.254"
-    ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
-    mac: "AA:AA:AA:AA:AA:AA"
+  ip: "172.16.254.254"
+  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+  mac: "AA:AA:AA:AA:AA:AA"
 is_pe: false
 ```
 

--- a/moduleroot/spec/default_facts.yml.erb
+++ b/moduleroot/spec/default_facts.yml.erb
@@ -1,3 +1,4 @@
+<% require 'yaml' -%>
 # Use default_module_facts.yml for module specific facts.
 #
 # Facts specified here will override the values provided by rspec-puppet-facts.
@@ -6,9 +7,13 @@ networking:
   ip: "<%= @configs['networking']['ip'] %>"
   ip6: "<%= @configs['networking']['ip6'] %>"
   mac: "<%= @configs['networking']['mac'] %>"
-
+<% if @configs.dig('extra_facts', 'networking') -%>
+<% @configs['extra_facts']['networking'].each do |k, v| -%>
+  <%=k%>: "<%= v %>"
+<% end -%>
+<% @configs['extra_facts'].delete('networking') -%>
+<% end -%>
 is_pe: <%= @configs['is_pe'] %>
-<% if !@configs['extra_facts'].nil? -%>
-<% require 'yaml' -%>
+<% if @configs.dig('extra_facts') && !@configs['extra_facts'].empty? -%>
 <%= @configs['extra_facts'].to_yaml[4..-1] %>
 <% end -%>


### PR DESCRIPTION
## Summary
This change allows the user to specify nested facts within their .sync.yml.
Before, if a user specified a networking fact in their .sync.yml with the below
```
spec/default_facts.yml:
  extra_facts:
    networking:
      hostname: "kubernetes.localhost"
```
it would result in a duplicate key error in the default_facts.yml, like this:
```
networking:
  ip: "172.16.254.254"
  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
  mac: "AA:AA:AA:AA:AA:AA"
is_pe: false
networking:
  hostname: "kubernetes.localhost"
``` 
## Additional Context
Now, when extra_facts is passed it will check for networking facts first, before clearing them and adding extra_facts as before.
A .sync.yml like below, will result in the following:
```
spec/default_facts.yml:
  extra_facts:
    networking:
      hostname: "kubernetes.localhost"
      domain: "localhost"
      fqdn: "foo.example.com"
    os:
      family: "debian"
      name: "debian"
```
default_facts.yml
```
---
networking:
  ip: "172.16.254.254"
  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
  mac: "AA:AA:AA:AA:AA:AA"
  hostname: "kubernetes.localhost"
  domain: "localhost"
  fqdn: "foo.example.com"
is_pe: false
os:
  family: debian
  name: debian

```
## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
