### PR TITLE
(maint) - bump puppet-strings to ~> 4.0

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -537,7 +537,7 @@ Gemfile:
       - gem: 'rubocop-rspec'
         version: '= 2.19.0'
       - gem: 'puppet-strings'
-        version: '~> 3.0'
+        version: '~> 4.0'
       - gem: 'rb-readline'
         version: '= 0.5.5'
         platforms:


### PR DESCRIPTION
Prerequisite:
  Requires a new release of bolt containing this change https://github.com/puppetlabs/bolt/pull/3216.
