### PR TITLE
[CAT-1541] : Adding github directory to pdkignore

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -44,6 +44,7 @@ common:
     - '/.fixtures.yml'
     - '/Gemfile'
     - '/.gitattributes'
+    - '/.github/'
     - '/.gitignore'
     - '/.pdkignore'
     - '/.puppet-lint.rc'


### PR DESCRIPTION
## Summary
Request coming in through community wants the modules build to ignore the github directory as it adds to the build size of each module.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
