### PR TITLE
(CAT-1606) - Adding gem group for release_pre

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -554,6 +554,11 @@ Gemfile:
           - x64_mingw
       - gem: 'serverspec'
         version: '~> 2.41'
+    ':release_prep':
+      - gem: 'puppet-strings'
+        version: '~> 4.0'
+      - gem: 'puppetlabs_spec_helper'
+        version: '~> 6.0'
 spec/default_facts.yml:
   is_pe: false
   networking:


### PR DESCRIPTION
## Summary

We have multiple use cases where we are installing all gems every time which also lead to installing old gems or conflicts, so creating `release_prep` for releasing the module.


## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
