### PR TITLE
(MAINT) - Updating puppetlabs_spec_helper gem version to latest

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -515,8 +515,6 @@ Gemfile:
         version: '~> 1.18'
       - gem: 'metadata-json-lint'
         version: '~> 3.0'
-      - gem: 'puppetlabs_spec_helper'
-        version: '~> 6.0'
       - gem: 'rspec-puppet-facts'
         version: '~> 2.0'
       - gem: 'codecov'
@@ -537,8 +535,6 @@ Gemfile:
         version: '= 1.16.0'
       - gem: 'rubocop-rspec'
         version: '= 2.19.0'
-      - gem: 'puppet-strings'
-        version: '~> 4.0'
       - gem: 'rb-readline'
         version: '= 0.5.5'
         platforms:
@@ -558,7 +554,7 @@ Gemfile:
       - gem: 'puppet-strings'
         version: '~> 4.0'
       - gem: 'puppetlabs_spec_helper'
-        version: '~> 6.0'
+        version: '~> 7.0'
 spec/default_facts.yml:
   is_pe: false
   networking:


### PR DESCRIPTION
## Summary

Updating `puppetlabs_spec_helper-version` gem version.


## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
