### PR TITLE
(CAT-1686) Upgrade Rubocop 1.48.1 to 1.50.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'rubocop', '= 1.48.1',                       require: false
+gem 'rubocop', '= 1.50.0',                       require: false
 gem 'rubocop-performance', '= 1.16.0',           require: false
 gem 'rubocop-rspec', '= 2.19.0',                 require: false

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -532,7 +532,7 @@ Gemfile:
       - gem: 'puppet-debugger'
         version: '~> 1.0'
       - gem: 'rubocop'
-        version: '= 1.48.1'
+        version: '= 1.50.0'
       - gem: 'rubocop-performance'
         version: '= 1.16.0'
       - gem: 'rubocop-rspec'

--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -35,7 +35,7 @@ profile = @configs['profiles'][@configs['selected_profile']]
 configs = defaults.dup
 DeepMerge::deep_merge!(profile['configs'], configs, knockout_prefix: "--", preserve_unmergeables: false)
 
-default_version = '1.48.1'
+default_version = '1.50.0'
 
 # rubocop's dependencies have native extensions and are not available on windows currently
 # to preserve the dynamic behaviour, and still work in its current state, this workaround

--- a/rubocop/defaults-1.50.0.yml
+++ b/rubocop/defaults-1.50.0.yml
@@ -519,6 +519,7 @@
 - Lint/DeprecatedConstants
 - Lint/DuplicateBranch
 - Lint/DuplicateMagicComment
+- Lint/DuplicateMatchPattern
 - Lint/DuplicateRegexpCharacterClassElement
 - Lint/EmptyBlock
 - Lint/EmptyClass
@@ -589,6 +590,7 @@
 - Style/CollectionCompact
 - Style/ComparableClamp
 - Style/ConcatArrayLiterals
+- Style/DataInheritance
 - Style/DirEmpty
 - Style/DocumentDynamicEvalDefinition
 - Style/EmptyHeredoc
@@ -623,6 +625,7 @@
 - Style/RedundantEach
 - Style/RedundantHeredocDelimiterQuotes
 - Style/RedundantInitialize
+- Style/RedundantLineContinuation
 - Style/RedundantSelfAssignmentBranch
 - Style/RedundantStringEscape
 - Style/SelectByRegexp


### PR DESCRIPTION
Following a recent team decision, we are implementing a Rubocop Upgrade, moving the version from 1.48.1 to 1.50.0. This should be the final version until Puppet 7 is unsupported. This change should help any module dependant on PDK to easily update.

