### PR TITLE
(BUGFIX) Enable NewCops by default

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -6,6 +6,7 @@ defaults = {
     'rubocop-rspec',
   ],
   'AllCops' => {
+    'NewCops' => 'enable',
     'DisplayCopNames' => true,
     'TargetRubyVersion' => '2.6',
     'Include' => [


### PR DESCRIPTION
This had previously been manually added to the Modules, however adding it here to ensure that it stayed in place had been missed.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
