### PR TITLE
(CAT-1688) - Pin rubocop to `~> 1.50.0`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'rubocop', '= 1.50.0',                       require: false
+gem 'rubocop', '~> 1.50.0',                      require: false
 gem 'rubocop-performance', '= 1.16.0',           require: false
 gem 'rubocop-rspec', '= 2.19.0',                 require: false

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -532,7 +532,7 @@ Gemfile:
       - gem: 'puppet-debugger'
         version: '~> 1.0'
       - gem: 'rubocop'
-        version: '= 1.50.0'
+        version: '~> 1.50.0'
       - gem: 'rubocop-performance'
         version: '= 1.16.0'
       - gem: 'rubocop-rspec'


### PR DESCRIPTION
Following the completion of CAT-1686, it was noticed that pdk-templates was assigned the wrong expectation, asserting a static (=) version instead of a pessimistic expectation (~).

This PR aims to fix this.
