### PR TITLE
(CAT-1693) - Remove deprecated codecov gem

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -519,8 +519,6 @@ Gemfile:
         version: '~> 6.0'
       - gem: 'rspec-puppet-facts'
         version: '~> 2.0'
-      - gem: 'codecov'
-        version: '~> 0.2'
       - gem: 'dependency_checker'
         version: '~> 1.0.0'
       - gem: 'parallel_tests'

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -526,7 +526,7 @@ Gemfile:
       - gem: 'pry'
         version: '~> 0.10'
       - gem: 'simplecov-console'
-        version: '~> 0.5'
+        version: '~> 0.9'
       - gem: 'puppet-debugger'
         version: '~> 1.0'
       - gem: 'rubocop'


### PR DESCRIPTION
## Summary

the codecov gem is deprecated, and no longer required in
puppetlabs_spec_helper. We should remove this from the pdk-templates
configu defaults, as it has stopped receiving updates and is restricting
us on the versions of simplecov we can consume.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
