### PR TITLE
puppetlabs_spec_helper: Require 7.X

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -543,7 +543,7 @@ Gemfile:
       - gem: 'puppet-strings'
         version: '~> 4.0'
       - gem: 'puppetlabs_spec_helper'
-        version: '~> 6.0'
+        version: '~> 7.0'
     ':system_tests':
       - gem: 'puppet_litmus'
         version: 


### PR DESCRIPTION
We're using this since some time at Vox Pupuli and I think Puppet should also use the latest version of their own software. Tested for development group in https://github.com/puppetlabs/puppetlabs-apt/blob/main/Gemfile#L26