### PR TITLE
Replace archived ruby vscode extension

### DIFF
--- a/moduleroot/.vscode/extensions.json
+++ b/moduleroot/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "puppet.puppet-vscode",
-    "rebornix.Ruby"
+    "Shopify.ruby-lsp"
   ]
 }


### PR DESCRIPTION
## Summary
`rebornix.Ruby` VS Code extension repo was archived on Aug 1, 2023 (https://github.com/rubyide/vscode-ruby?tab=readme-ov-file#deprecated). `Shopify.ruby-lsp` is recommended instead.

## Additional Context

## Related Issues (if any)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
