### PR TITLE
Add bolt-related files to .gitignore default paths

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -38,6 +38,12 @@ common:
     - '.envrc'
     - '/inventory.yaml'
     - '/spec/fixtures/litmus_inventory.yaml'
+    - '.resource_types'
+    - '.modules'
+    - '.task_cache.json'
+    - '.plan_cache.json'
+    - '.rerun.json'
+    - 'bolt-debug.log'
 .pdkignore:
   required: *ignorepaths
   paths:


### PR DESCRIPTION
## Summary
When using PDK with a Bolt project it's usually expected to ignore some more files.

```yaml
    - '.resource_types'
    - '.modules'
    - '.task_cache.json'
    - '.plan_cache.json'
    - '.rerun.json'
    - 'bolt-debug.log'
    - 'Puppetfile'
```
