### PR TITLE
Revert "(BUGFIX) Enable NewCops by default"

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -6,7 +6,6 @@ defaults = {
     'rubocop-rspec',
   ],
   'AllCops' => {
-    'NewCops' => 'enable',
     'DisplayCopNames' => true,
     'TargetRubyVersion' => '2.6',
     'Include' => [


### PR DESCRIPTION
This commit initially was created as a way to be able to automate a large chunk of work regarding Rubocop file amends, during our Puppet 8 work back in April 2023. However, once such work was performed, this fix was no longer needed and it, effectively, introduced a bug where cop rules cannot be configured via sync.yml if they have been actively set to enabled here.

This commit aims to address the current bug by reverting the previous change.

Reverts puppetlabs/pdk-templates#554