### PR TITLE
Re-implement "(BUGFIX) Enable NewCops by default"

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -6,6 +6,7 @@ defaults = {
     'rubocop-rspec',
   ],
   'AllCops' => {
+    'NewCops' => 'enable',
     'DisplayCopNames' => true,
     'TargetRubyVersion' => '2.6',
     'Include' => [


### PR DESCRIPTION
Upon further testing, it was concurred that removing this feature did not fix the current problem. Therefore, we are undoing the revert.

Reverts puppetlabs/pdk-templates#566