### PR TITLE
(CAT-1743) Address .sync.yml not overriding cops

### DIFF
--- a/.ci/fixtures/new_provider_sync.yml
+++ b/.ci/fixtures/new_provider_sync.yml
@@ -7,5 +7,5 @@ spec/spec_helper.rb:
   mock_with: ':rspec'
 .rubocop.yml:
   default_configs:
-    Lint/EnsureReturn:
+    Performance/CaseWhenSplat:
       Enabled: false

--- a/.ci/fixtures/new_provider_sync.yml
+++ b/.ci/fixtures/new_provider_sync.yml
@@ -5,3 +5,7 @@ Gemfile:
       - gem: 'puppet-resource_api'
 spec/spec_helper.rb:
   mock_with: ':rspec'
+.rubocop.yml:
+  default_configs:
+    Lint/EnsureReturn:
+      Enabled: false

--- a/.ci/test_script.sh
+++ b/.ci/test_script.sh
@@ -13,7 +13,9 @@ pdk new module new_module --template-url="file://$TEMPLATE_PR_DIR" --template-re
 pushd new_module
 grep template < metadata.json
 cp "$TEMPLATE_PR_DIR/.ci/fixtures/new_provider_sync.yml" ./.sync.yml
+grep -A 1 "Performance/CaseWhenSplat" ./.rubocop.yml | grep -q "true" # Ensure that the template is applied
 pdk update --force
+grep -A 1 "Performance/CaseWhenSplat" ./.rubocop.yml | grep -q "false" # Ensure that the update command changes the template
 pdk new class new_module
 pdk new defined_type test_type
 pdk new fact test_fact || true # not available in pdk 1.18 yet

--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -56,11 +56,13 @@ dynamic_path = File.absolute_path(File.join(base_path, "defaults-#{version}.yml"
 default_path = File.absolute_path(File.join(base_path, "defaults-#{default_version}.yml"))
 path = File.exist?(dynamic_path) ? dynamic_path : default_path
 
+# The following block builds default_enabled_cops and default_pending_cops based on the existing values at defaults-<current_version>.yml, which usually lives at ∼/rubocop/
 require 'yaml'
 config_defaults = YAML.load(File.read(path))
 default_enabled_cops = config_defaults[:default_enabled_cops] || []
 default_pending_cops = config_defaults[:default_pending_cops] || []
 
+# This line builds cop_configs based on the values existing at profile, which was previously configured to retrieve the values of a specific profile in config_defaults.yml
 cop_configs = (profile['enabled_cops'] || {})
 
 if cop_configs == 'all'
@@ -71,12 +73,20 @@ else
   enabled_cops = []
 end
 
+# Create a filtered list of enabled cops that should be disabled.
+disabled_cops = enabled_cops.select { |c| configs[c] && configs[c]['Enabled'] == false }
+
+# The following block builds the final configuration based on the values of enabled_cops, default_enabled_cops, default_pending_cops, and cop_configs
 (enabled_cops & default_enabled_cops).sort.each { |c| configs[c] ||= cop_configs[c] if cop_configs[c] }
 (enabled_cops - default_enabled_cops).sort.each { |c| configs[c] ||= cop_configs[c] || {}; configs[c]['Enabled'] = true }
 (default_enabled_cops - enabled_cops).sort.each { |c| configs[c] ||= cop_configs[c] || {}; configs[c]['Enabled'] = false }
 
 # force set pending cops to something to avoid the messages
-(default_pending_cops & enabled_cops).sort.each { |c| configs[c] ||= cop_configs[c] if cop_configs[c]; configs[c]['Enabled'] = true }
+(default_pending_cops & enabled_cops).sort.each { |c| configs[c] ||= cop_configs[c] if cop_configs[c]; configs[c]['Enabled'] = true } 
 (default_pending_cops - enabled_cops).sort.each { |c| configs[c] = { 'Enabled' => false } }
+
+# Set overriden cops to false if 'Enabled: false'. This can be the case when users override default behaviour via .sync.yml
+(disabled_cops).sort.each { |c| configs[c] = { 'Enabled' => false } }
+
 -%>
 <%= YAML.dump(configs) -%>


### PR DESCRIPTION
Prior to this commit, it was noticed that Rubocop rules that were set to false in .sync.yml would not be properly overriden if the cop already existed as a default enabled cop.

This commit aims to correct this unintended functionality and adds a test case.
