### PR TITLE
(CAT-1868) - Remove .rspec.erb

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -551,7 +551,7 @@ Gemfile:
       - gem: 'puppet-strings'
         version: '~> 4.0'
       - gem: 'puppetlabs_spec_helper'
-        version: '~> 7.0'
+        version: '~> 7.3'
     ':system_tests':
       - gem: 'puppet_litmus'
         version:

--- a/moduleroot/.rspec.erb
+++ b/moduleroot/.rspec.erb
@@ -1,2 +1,0 @@
---color
---format documentation


### PR DESCRIPTION
## Summary
This PR removes the .rspec.erb file from the pdk-templates, and thus the .rspec file from being managed by PDK. This was made possible due to the changes found in https://github.com/puppetlabs/puppetlabs_spec_helper/pull/452.

This has minimal impact on users as the file was not configurable through .sync.yml before (other than to set as unmanaged), for existing modules with the .rspec it will not be removed and new modules created will simply not include the file.

## Additional Context
https://github.com/puppetlabs/puppetlabs_spec_helper/pull/452.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
