### PR TITLE
(CAT-1871) Pin `rexml` due to issues on Windows

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -547,6 +547,11 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
+      # Temporary Pin
+      - gem: 'rexml'
+        version: 
+          - '>= 3.0.0'
+          - '< 3.2.7'
     ':development, :release_prep':
       - gem: 'puppet-strings'
         version: '~> 4.0'


### PR DESCRIPTION
See issue below:
https://github.com/ruby/rexml/issues/131

## Checklist
- [x] 🟢 Spec tests.
- [x] Manually verified.
