### PR TITLE
fix: add config extras handling back to Rakefile

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -41,3 +41,7 @@ PuppetLint.configuration.send('<%= option %>')
 <% if @configs['linter_exclusions'] -%>
 PuppetLint.configuration.ignore_paths = <%= @configs['linter_exclusions']%>
 <% end -%>
+
+<%- [@configs['extras']].flatten.compact.each do |line| -%>
+<%= line %>
+<%- end -%>


### PR DESCRIPTION


## Summary
In https://github.com/puppetlabs/pdk-templates/commit/e0fc78f45f99b9ea3b0f9af6db6541fe6eee1a50 the last 3 lines should not have been removed. Now it is not possible to add custom code to the Rakefile anymore via Rakefile extras in .sync.yml

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.

fixes #589