### PR TITLE
(CAT-1887) - remove pinned version of rexml

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -547,11 +547,6 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
-      # Temporary Pin
-      - gem: 'rexml'
-        version: 
-          - '>= 3.0.0'
-          - '< 3.2.7'
     ':development, :release_prep':
       - gem: 'puppet-strings'
         version: '~> 4.0'


### PR DESCRIPTION
## Summary
This pull request removes the pinned version of rexml as it is no longer need as the latest release resolves the issue with rexml gem on windows 

## Related Issues (if any)
https://github.com/puppetlabs/pdk-templates/compare/cat_1887?expand=1
