### PR TITLE
Update facterdb to 3.x and rspec-puppet-facts to 5.x

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -539,12 +539,20 @@ Gemfile:
         version: '~> 5.0'
       - gem: 'facterdb'
         version: '~> 2.1'
+        condition: "Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
+      - gem: 'facterdb'
+        version: '~> 3.0'
+        condition: "Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
       - gem: 'metadata-json-lint'
         version: '~> 4.0'
       - gem: 'json-schema'
         version: '< 5.1.1'
       - gem: 'rspec-puppet-facts'
         version: '~> 4.0'
+        condition: "Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
+      - gem: 'rspec-puppet-facts'
+        version: '~> 5.0'
+        condition: "Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
       - gem: 'dependency_checker'
         version: '~> 1.0.0'
       - gem: 'parallel_tests'


### PR DESCRIPTION
## Summary
Update facterdb from 1.x to 3.x and update rspec-puppet-facts from 3.x to 5.x.

## Additional Context
Upstream facterdb and rspec-puppet-facts have removed support for legacy facts, which is useful for testing for Puppet 8.

See https://github.com/voxpupuli/facterdb/blob/master/CHANGELOG.md and https://github.com/voxpupuli/rspec-puppet-facts/blob/master/CHANGELOG.md for more details.

## Related Issues (if any)
N/A

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
