### PR TITLE
.gitignore: Add /.vendor/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /spec/fixtures/modules/
 /tmp/
 /vendor/
+/.vendor/
 /convert_report.txt
 # Rubocop profile builder temporary files
 /rubocop/.rubocop.yml

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -31,6 +31,7 @@ common:
     - '/spec/fixtures/modules/*'
     - '/tmp/'
     - '/vendor/'
+    - '/.vendor/'
     - '/convert_report.txt'
     - '/update_report.txt'
     - '.DS_Store'


### PR DESCRIPTION
In many projects it's common to install gems into .vendor/, not vendor/. people tend to copy and paste commands from their history. I think it makes sense to add it to the .gitignore here as well.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
