### PR TITLE
Revert "(CAT-1887) - remove pinned version of rexml"

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -547,6 +547,11 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
+      # Temporary Pin
+      - gem: 'rexml'
+        version: 
+          - '>= 3.0.0'
+          - '< 3.2.7'
     ':development, :release_prep':
       - gem: 'puppet-strings'
         version: '~> 4.0'


### PR DESCRIPTION
Reverts puppetlabs/pdk-templates#592

Reverting as it looks like the issues are still occurring.
Problem nature of PR seems to have been hidden by the exact way in which the test builds are run.