### PR TITLE
(CAT-2056) - add puppet-blacksmith to templates

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -557,7 +557,7 @@ Gemfile:
       - gem: 'puppet-strings'
         version: '~> 4.0'
       - gem: 'puppetlabs_spec_helper'
-        version: '~> 7.0'
+        version: '~> 8.0'
       - gem: 'puppet-blacksmith'
         version: '~> 7.0'
     ':system_tests':

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -558,6 +558,8 @@ Gemfile:
         version: '~> 4.0'
       - gem: 'puppetlabs_spec_helper'
         version: '~> 7.0'
+      - gem: 'puppet-blacksmith'
+        version: '~> 7.0'
     ':system_tests':
       - gem: 'puppet_litmus'
         version:


### PR DESCRIPTION
## Summary
Module build rake tasks are scheduled for removal in `puppetlabs_spec_helper v8`. `puppet-blacksmith` offers a range of rake tasks, and was already included in `puppetlabs_spec_helper` as a soft dependency, so we should avail of these instead of producing duplicate logic and rake tasks.

This adds the puppet-blacksmith gem to the pdk-templates, and bumps puppetlabs_spec_helper to v8.

## Additional Context
https://github.com/puppetlabs/puppetlabs_spec_helper/pull/472
## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
