### PR TITLE
(CAT-2010) Update lint configuration to match puppetlabs_spec_helper

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -68,8 +68,23 @@ common:
   markup: markdown
 Rakefile:
   changelog_version_tag_pattern: 'v%s'
+  linter_fail_on_warnings: true
   default_disabled_lint_checks:
     - 'relative'
+    - '80chars'
+    - '140chars'
+    - 'class_inherits_from_params_class'
+    - 'autoloader_layout'
+    - 'documentation'
+    - 'single_quote_string_with_variables'
+  linter_exclusions:
+    - '.vendor/**/*.pp'
+    - 'bundle/**/*.pp'
+    - 'pkg/**/*.pp'
+    - 'spec/**/*.pp'
+    - 'tests/**/*.pp'
+    - 'types/**/*.pp'
+    - 'vendor/**/*.pp'
   extras: []
 .rubocop.yml:
   selected_profile: strict


### PR DESCRIPTION
Update the configuration of lint with the templates to match that of the puppetlabs_spec_helper to ensure compliance between the PDK lint runs and the Rake lint runs.
Due to how the templates work, `Rakefile` configurations are inherited by the `.puppet-lint.rc`

## Checklist
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
