### PR TITLE
(BUGFIX) Correcting typo in linter exclusions

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -81,7 +81,7 @@ Rakefile:
     - 'single_quote_string_with_variables'
   linter_exclusions:
     - '.vendor/**/*.pp'
-    - 'bundle/**/*.pp'
+    - '.bundle/**/*.pp'
     - 'pkg/**/*.pp'
     - 'spec/**/*.pp'
     - 'tests/**/*.pp'


### PR DESCRIPTION
Following a Linter error tracking, it was found that the linter was not excluding the correct files. This commit corrects the typo in the linter exclusions.
