### PR TITLE
(CAT-2158) Upgrade rexml to address CVE-2024-49761

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -568,8 +568,7 @@ Gemfile:
       # Temporary Pin
       - gem: 'rexml'
         version: 
-          - '>= 3.0.0'
-          - '< 3.2.7'
+          - '>= 3.3.9'
     ':development, :release_prep':
       - gem: 'puppet-strings'
         version: '~> 4.0'


### PR DESCRIPTION
## Summary

See https://nvd.nist.gov/vuln/detail/CVE-2024-49761

> REXML is an XML toolkit for Ruby. The REXML gem before 3.3.9 has a ReDoS vulnerability when it parses an XML that has many digits between &# and x...; in a hex numeric character reference (&#x...;). This does not happen with Ruby 3.2 or later. Ruby 3.1 is the only affected maintained Ruby. The REXML gem 3.3.9 or later include the patch to fix the vulnerability.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
