### PR TITLE
(BUGFIX) Pin json-schema below 5.1.1 to resolve issues with Ruby 2 on Windows

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -541,6 +541,8 @@ Gemfile:
         version: '~> 2.1'
       - gem: 'metadata-json-lint'
         version: '~> 4.0'
+      - gem: 'json-schema'
+        version: '< 5.1.1'
       - gem: 'rspec-puppet-facts'
         version: '~> 4.0'
       - gem: 'dependency_checker'


### PR DESCRIPTION
PDK build step is currently failing on Windows with regards to Ruby 2 due to a conflict with the gem bigdecimal which has been brought in by json-schema 5.1.1

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
