### PR TITLE
(CAT-1887) Remove rexml pin

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -567,11 +567,6 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
-      # Temporary Pin
-      - gem: 'rexml'
-        version: 
-          - '>= 3.0.0'
-          - '< 3.2.7'
     ':development, :release_prep':
       - gem: 'puppet-strings'
         version: '~> 4.0'


### PR DESCRIPTION
This pin was added to get around an issue on the windows machines, testing seems to show that this is no longer necessary

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
