### PR TITLE
Only pin to the puppetcore versions.

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -112,8 +112,8 @@ hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 # If PUPPET_FORGE_TOKEN is set then use authenticated source for both puppet and facter, since facter is a transitive dependency of puppet
 # Otherwise, do as before and use location_for to fetch gems from the default source
 if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gems['puppet'] = [puppet_version || '~> 8.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
-  gems['facter'] = [facter_version || '~> 4.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
+  gems['puppet'] = ['~> 8.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
+  gems['facter'] = ['~> 4.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
 else
   gems['puppet'] = location_for(puppet_version)
   gems['facter'] = location_for(facter_version) if facter_version


### PR DESCRIPTION
Since the `PUPPET_GEM_VERSION` and `FACTER_GEM_VERSION` are not always going to be version contraints (they can also be a git URL), then I'm removing this flexible check and pinning only to the latest puppetcore gems.  If flexible puppet and facter gemsources are need via https or git, then remove the PUPPET_FORGE_TOKEN and use PUPPET_GEM_VERSION and/or FACTER_GEM_VERSION instead.

## Checklist
- [x] Manually verified.
