### PR TITLE
(CAT-2283) Fix CI failures by using non-expiring Puppet GPG key

### DIFF
--- a/.ci/install_pdk.sh
+++ b/.ci/install_pdk.sh
@@ -12,6 +12,9 @@ setup_apt() {
 
     wget "${deb_url}"
     sudo dpkg -i "${deb_file}"
+    
+    # Add the non-expiring key from the future endpoint
+    curl -fsSL https://apt.puppetlabs.com/DEB-GPG-KEY-future | sudo apt-key add -
 }
 
 main() {


### PR DESCRIPTION
## Problem

The Puppet GPG key (D6811ED3ADEEB8441AF5AA8F4528B6CD9E61EF26) expired on April 6, 2025, causing CI failures with the error:

```bash
W: GPG error: [http://apt.puppet.com](http://apt.puppet.com) noble InRelease:
The following signatures were invalid: EXPKEYSIG 4528B6CD9E61EF26
Puppet, Inc. Release Key (Puppet, Inc. Release Key) <release@puppet.com>
```

This commit adds a step to fetch the non-expiring version of the same key <https://apt.puppetlabs.com/DEB-GPG-KEY-future> ensuring the CI pipeline can validate the repository signature.

## Solution

This PR modifies the `.ci/install_pdk.sh`  to 

* Fetch and add the non-expiring version of the same key
* Install the pdk package as before.

## Testing Done

- Verified that the key ID from DEB-GPG-KEY-future matches the expired key ID
- Confirmed this modification fixes the CI failures