### PR TITLE
(CAT-2286) Remove Ruby < 3.1 dependencies

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -515,15 +515,6 @@ Gemfile:
       # Json gems should be pinned to their default versions so that users aren't forced to recompile the native extensions.
       # See the following for a version matrix: https://stdgems.org/json/#gem-version
       - gem: json
-        version: '= 2.1.0'
-        condition: "Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
-      - gem: json
-        version: '= 2.3.0'
-        condition: "Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
-      - gem: json
-        version: '= 2.5.1'
-        condition: "Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
-      - gem: json
         version: '= 2.6.1'
         condition: "Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
       - gem: json

--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -8,7 +8,7 @@ defaults = {
   'AllCops' => {
     'NewCops' => 'enable',
     'DisplayCopNames' => true,
-    'TargetRubyVersion' => '2.6',
+    'TargetRubyVersion' => '3.1',
     'Include' => [
       '**/*.rb',
     ],


### PR DESCRIPTION
With the EOL of Puppet 7, we no longer need to support Ruby < 3.1.
