### PR TITLE
(CAT-2319) Pin bigdecimal on windows

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -566,6 +566,12 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
+      - gem: 'bigdecimal'
+        version: '< 3.2.2'
+        platforms:
+          - mswin
+          - mingw
+          - x64_mingw
     ':development, :release_prep':
       - gem: 'puppet-strings'
         version: '~> 4.0'


### PR DESCRIPTION
## Summary
bigdecimal version 3.2.2 is causing conflicts on Windows machines. Pinning this as lower in order to resolve until a new version is released that fixes it.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
