### PR TITLE
(CAT-2357) Update puppet_litmus pin to test against puppetcore

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -582,10 +582,18 @@ Gemfile:
     ':system_tests':
       - gem: 'puppet_litmus'
         version:
+        - '~> 2.0'
+        platforms:
+          - ruby
+          - x64_mingw
+        condition: "!ENV['PUPPET_FORGE_TOKEN'].to_s.empty?"
+      - gem: 'puppet_litmus'
+        version:
         - '~> 1.0'
         platforms:
           - ruby
           - x64_mingw
+        condition: "ENV['PUPPET_FORGE_TOKEN'].to_s.empty?"
       - gem: 'CFPropertyList'
         version:
         - '< 3.0.7'

--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -8,7 +8,7 @@ defaults = {
   'AllCops' => {
     'NewCops' => 'enable',
     'DisplayCopNames' => true,
-    'TargetRubyVersion' => '3.1',
+    'TargetRubyVersion' => 3.1,
     'Include' => [
       '**/*.rb',
     ],


### PR DESCRIPTION
## Summary
Updating puppet_litmus to bring in changes to `matrix_from_metadata_v2` that point the tests towards the new puppetcore versions.

## Checklist
- [x] Manually verified.
