### PR TITLE
(CAT-2416) Enhance PDK Gemfile Template to Support Flexible Source Testing

### DIFF
--- a/docs/testing-pdk-module-gemfile-sources.md
+++ b/docs/testing-pdk-module-gemfile-sources.md
@@ -73,20 +73,6 @@ export TEMPLATE_URL="file:///Users/gavin.didrichsen/@REFERENCES/github/app/devel
 - **Local filesystem**: Use `--template-url="${TEMPLATE_URL}"`
 - **Git repository**: Use `--template-ref="${TEMPLATE_REF}" --template-branch="${TEMPLATE_BRANCH}"`
 
-#### Advantages of Local Filesystem Path
-
-- **Speed**: No network latency or git operations
-- **Real-time testing**: Test changes immediately without committing/pushing
-- **Offline development**: Works without internet connection
-- **Debugging**: Easy to modify template and retest quickly
-- **Iteration**: Perfect for development workflow
-
-#### When to Use Each Option
-
-- **Local Filesystem**: Development, testing, debugging template changes
-- **Git Repository**: CI/CD, sharing with team, production testing
-- **File URL**: Alternative to filesystem path, some PDK versions prefer this format
-
 ### Create Helper Scripts
 
 Before running any scenarios, make sure to export `PUPPET_FORGE_TOKEN` with a valid token if you have access to puppetcore:

--- a/docs/testing-pdk-module-gemfile-sources.md
+++ b/docs/testing-pdk-module-gemfile-sources.md
@@ -4,6 +4,12 @@
 
 This guide shows you how to manually test all gem source scenarios for PDK modules using the enhanced Gemfile template. These tests validate real gem installation behavior across different sources: rubygems.org, authenticated puppetcore, git repositories, and local file paths when developing or testing Puppet modules with PDK.
 
+**Key Testing Areas:**
+
+- `pdk new module` - Creating new modules with enhanced Gemfile template
+- `pdk update` - Updating existing modules to use enhanced Gemfile template  
+- Various gem source configurations and combinations
+
 ## Prerequisites
 
 - **PDK Installed**: Latest version of PDK (Puppet Development Kit)
@@ -14,15 +20,72 @@ This guide shows you how to manually test all gem source scenarios for PDK modul
 
 ## Environment Setup
 
-### Create a Test Module
+### Testing Directory Structure
 
-Start by creating a new PDK module for testing:
+Create a dedicated testing directory structure:
 
 ```bash
-# Create a test module
-pdk new module test_module_sources --skip-interview
-cd test_module_sources
+# Create testing workspace
+mkdir -p ~/pdk_gemfile_testing
+cd ~/pdk_gemfile_testing
+
+# We'll create modules here:
+# - new_module_tests/     (for pdk new module testing)
+# - update_module_tests/  (for pdk update testing) 
 ```
+
+### Template Reference Setup
+
+To test the enhanced Gemfile template, you have several options for referencing your template:
+
+#### Option 1: Local Filesystem Path (Recommended for Development) ⭐
+
+```bash
+# Use local filesystem path - much faster for iterative testing
+export TEMPLATE_URL="/Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/repositories/puppetlabs/pdk-templates"
+
+# PDK uses --template-url for local filesystem paths
+# No branch parameter needed for local filesystem
+```
+
+#### Option 2: Git Repository Reference (Remote)
+
+```bash
+# Set template reference variables for your testing
+export TEMPLATE_REF="https://github.com/puppetlabs/pdk-templates.git"
+export TEMPLATE_BRANCH="cat_2416_fix_pdk_templates_gemfile"  # Your feature branch
+
+# Alternative: Use specific commit hash if needed
+# export TEMPLATE_BRANCH="35f8fc1"  # Specific commit hash
+```
+
+#### Option 3: File URL Format
+
+```bash
+# Alternative file URL format (some PDK versions prefer this)
+export TEMPLATE_URL="file:///Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/repositories/puppetlabs/pdk-templates"
+```
+
+**Recommendation**: Use Option 1 (local filesystem path) for development and testing as it's much faster and doesn't require network access or git operations.
+
+#### PDK Command Differences
+
+- **Local filesystem**: Use `--template-url="${TEMPLATE_URL}"`
+- **Git repository**: Use `--template-ref="${TEMPLATE_REF}" --template-branch="${TEMPLATE_BRANCH}"`
+
+#### Advantages of Local Filesystem Path
+
+- **Speed**: No network latency or git operations
+- **Real-time testing**: Test changes immediately without committing/pushing
+- **Offline development**: Works without internet connection
+- **Debugging**: Easy to modify template and retest quickly
+- **Iteration**: Perfect for development workflow
+
+#### When to Use Each Option
+
+- **Local Filesystem**: Development, testing, debugging template changes
+- **Git Repository**: CI/CD, sharing with team, production testing
+- **File URL**: Alternative to filesystem path, some PDK versions prefer this format
 
 ### Create Helper Scripts
 
@@ -57,141 +120,338 @@ chmod +x set_puppetcore_authentication.sh
 
 ## Testing Scenarios
 
-### Scenario 1: Default Public RubyGems
+### Phase 1: PDK New Module Testing
 
-Test basic functionality with public rubygems.org as the default source.
+Create new modules using the enhanced Gemfile template to test initial setup scenarios.
+
+#### Scenario 1: Default Public RubyGems (New Module)
+
+Create a new module and test basic functionality with public rubygems.org.
 
 ```bash
-source ./clean_environment.sh
+cd ~/pdk_gemfile_testing
+mkdir -p new_module_tests && cd new_module_tests
+source ../clean_environment.sh
+
+# Create new module with enhanced template (local filesystem)
+pdk new module test_default_gems --skip-interview --template-url="${TEMPLATE_URL}"
+
+# Alternative for Git repository:
+# pdk new module test_default_gems --skip-interview \
+#   --template-ref="${TEMPLATE_REF}" \
+#   --template-branch="${TEMPLATE_BRANCH}"
+
+cd test_default_gems
+
+# Test gem installation and sources
 pdk bundle install
 pdk bundle info puppet    # Expected: Latest public puppet version, e.g., 8.10.0 from rubygems.org
 pdk bundle info facter    # Expected: Latest public facter version, e.g., 4.10.0 from rubygems.org
 
-# Expected: gem source for puppet and facter is rubygems.org
+# Verify gem sources
 cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
+
+# Test PDK functionality
+pdk validate
+pdk new class example_class
+pdk test unit
 ```
 
-### Scenario 2: Default RubyGems with Specific Versions
+#### Scenario 2: Authenticated Puppetcore (New Module)
 
-Test version constraints with public rubygems.org.
-
-```bash
-source ./clean_environment.sh
-export PUPPET_GEM_VERSION='~> 7.24.0'
-export FACTER_GEM_VERSION='= 4.4.0'
-pdk bundle install
-pdk bundle info puppet    # Expected: 7.24.x from rubygems.org
-pdk bundle info facter    # Expected: 4.4.0 from rubygems.org
-
-# Expected: gem source for puppet and facter is rubygems.org
-cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
-```
-
-### Scenario 3: Authenticated Puppetcore for puppet/facter
-
-Test authenticated puppetcore access (requires valid PUPPET_FORGE_TOKEN).
+Create a new module and test with authenticated puppetcore sources.
 
 ```bash
-source ./clean_environment.sh
-source ./set_puppetcore_authentication.sh
+cd ~/pdk_gemfile_testing/new_module_tests
+source ../clean_environment.sh
+source ../set_puppetcore_authentication.sh
 export GEM_SOURCE_PUPPETCORE='https://rubygems-puppetcore.puppet.com'
-pdk bundle install
-pdk bundle info puppet    # Expected: Latest puppetcore version from authenticated source
-pdk bundle info facter    # Expected: Latest puppetcore version from authenticated source
 
-# Expected: rubygems-puppetcore.puppet.com is gem source for both puppet and facter
+# Create new module with enhanced template (local filesystem)
+pdk new module test_puppetcore_gems --skip-interview \
+  --template-url="${TEMPLATE_URL}"
+
+# Alternative for Git repository:
+# pdk new module test_puppetcore_gems --skip-interview \
+#   --template-ref="${TEMPLATE_REF}" \
+#   --template-branch="${TEMPLATE_BRANCH}"
+
+cd test_puppetcore_gems
+
+# Test gem installation with puppetcore
+pdk bundle install
+pdk bundle info puppet    # Expected: Latest puppetcore version
+pdk bundle info facter    # Expected: Latest puppetcore version
+
+# Verify puppetcore sources
 cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
+
+# Test PDK functionality
+pdk validate
+pdk new class puppetcore_class
+pdk test unit
 ```
 
-### Scenario 4: Authenticated Puppetcore with Specific Versions
+#### Scenario 3: Git Repository Sources (New Module)
 
-Test version pinning with authenticated puppetcore sources.
-
-```bash
-source ./clean_environment.sh
-source ./set_puppetcore_authentication.sh
-export GEM_SOURCE_PUPPETCORE='https://rubygems-puppetcore.puppet.com'
-export PUPPET_GEM_VERSION='= 8.13.0'
-export FACTER_GEM_VERSION='= 4.13.0'
-pdk bundle install
-pdk bundle info puppet    # Expected: 8.13.0 from puppetcore
-pdk bundle info facter    # Expected: 4.13.0 from puppetcore
-
-# Expected: rubygems-puppetcore.puppet.com is gem source for both puppet and facter
-cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
-```
-
-### Scenario 5: Git Repository Sources
-
-Test development workflow with git repositories that override the existing gem sources.
+Create a new module and test with git-based gem sources.
 
 ```bash
-source ./clean_environment.sh
+cd ~/pdk_gemfile_testing/new_module_tests
+source ../clean_environment.sh
 export PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#main'
 export FACTER_GEM_VERSION='https://github.com/puppetlabs/facter.git#main'
+
+# Create new module with enhanced template (local filesystem)
+pdk new module test_git_gems --skip-interview \
+  --template-url="${TEMPLATE_URL}"
+
+# Alternative for Git repository:
+# pdk new module test_git_gems --skip-interview \
+#   --template-ref="${TEMPLATE_REF}" \
+#   --template-branch="${TEMPLATE_BRANCH}"
+
+cd test_git_gems
+
+# Test gem installation from git sources
 pdk bundle install
 pdk bundle info puppet    # Expected: Git version (e.g., '8.x.x ab48604')
 pdk bundle info facter    # Expected: Git version (e.g., '4.x.x 5554178')
 
-# Expected: github repos are the gemsources for both puppet and facter
+# Verify git sources
+cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
+
+# Test PDK functionality
+pdk validate
+pdk new class git_based_class
+```
+
+### Phase 2: PDK Update Testing
+
+Test updating existing modules to use the enhanced Gemfile template.
+
+#### Scenario 4: Update Existing Module to Enhanced Template
+
+Create a module with default template, then update to enhanced template.
+
+```bash
+cd ~/pdk_gemfile_testing
+mkdir -p update_module_tests && cd update_module_tests
+source ../clean_environment.sh
+
+# Create module with default PDK template first
+pdk new module test_update_module --skip-interview
+
+cd test_update_module
+
+# Check initial Gemfile (should be standard template)
+echo "=== Initial Gemfile content ==="
+cat Gemfile
+
+# Update to enhanced template (local filesystem)
+pdk update --template-url="${TEMPLATE_URL}"
+
+# Alternative for Git repository:
+# pdk update --template-ref="${TEMPLATE_REF}" --template-branch="${TEMPLATE_BRANCH}"
+
+# Check updated Gemfile (should now have enhanced features)
+echo "=== Updated Gemfile content ==="
+cat Gemfile
+
+# Test functionality with enhanced template
+pdk bundle install
+pdk validate
+pdk test unit
+```
+
+#### Scenario 5: Update with Custom Gem Sources
+
+Update existing module and test with custom gem sources.
+
+```bash
+cd ~/pdk_gemfile_testing/update_module_tests
+source ../clean_environment.sh
+source ../set_puppetcore_authentication.sh
+export GEM_SOURCE_PUPPETCORE='https://rubygems-puppetcore.puppet.com'
+
+# Create standard module
+pdk new module test_update_with_sources --skip-interview
+cd test_update_with_sources
+
+# Update to enhanced template (local filesystem)
+pdk update --template-url="${TEMPLATE_URL}"
+
+# Alternative for Git repository:
+# pdk update --template-ref="${TEMPLATE_REF}" --template-branch="${TEMPLATE_BRANCH}"
+
+# Test with custom sources
+pdk bundle install
+pdk bundle info puppet    # Expected: puppetcore version
+pdk bundle info facter    # Expected: puppetcore version
+
+# Verify sources
 cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
 ```
 
-### Scenario 6: Mixed Local and Remote Sources
+### Phase 3: Legacy Scenarios (Backwards Compatibility)
 
-Test facter from default source and puppet from local file path.
+#### Scenario 6: Version-Specific Testing
+
+Test version constraints work correctly with enhanced template.
 
 ```bash
-source ./clean_environment.sh
+cd ~/pdk_gemfile_testing/new_module_tests
+source ../clean_environment.sh
+export PUPPET_GEM_VERSION='~> 7.24.0'
+export FACTER_GEM_VERSION='= 4.4.0'
+
+pdk new module test_version_constraints --skip-interview \
+  --template-url="${TEMPLATE_URL}"
+
+# Alternative for Git repository:
+# pdk new module test_version_constraints --skip-interview \
+#   --template-ref="${TEMPLATE_REF}" \
+#   --template-branch="${TEMPLATE_BRANCH}"
+
+cd test_version_constraints
+
+pdk bundle install
+pdk bundle info puppet    # Expected: 7.24.x from rubygems.org
+pdk bundle info facter    # Expected: 4.4.0 from rubygems.org
+
+# Verify version constraints work
+cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
+```
+
+#### Scenario 7: Mixed Local and Remote Sources
+
+Test combination of local file paths and remote sources.
+
+```bash
+cd ~/pdk_gemfile_testing/new_module_tests
+source ../clean_environment.sh
 
 # Clone local puppet for testing
 git clone https://github.com/puppetlabs/puppet.git tmp/puppet
 export PUPPET_GEM_VERSION="file:///${PWD}/tmp/puppet"
+
+pdk new module test_mixed_sources --skip-interview \
+  --template-url="${TEMPLATE_URL}"
+
+# Alternative for Git repository:
+# pdk new module test_mixed_sources --skip-interview \
+#   --template-ref="${TEMPLATE_REF}" \
+#   --template-branch="${TEMPLATE_BRANCH}"
+
+cd test_mixed_sources
+
 pdk bundle install
 pdk bundle info puppet    # Expected: Local file path
 pdk bundle info facter    # Expected: Default source
 
-# Expected: file path gemsource for puppet and default gemsource for facter
+# Verify mixed sources
 cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
 ```
 
-### Scenario 7: Corporate Gem Source Override
+#### Scenario 8: Corporate Gem Source Override
 
 Test using a corporate gem mirror for all gems.
 
 ```bash
-source ./clean_environment.sh
+cd ~/pdk_gemfile_testing/new_module_tests
+source ../clean_environment.sh
 export GEM_SOURCE='https://your-corporate-mirror.com/rubygems/'
+
+pdk new module test_corporate_mirror --skip-interview \
+  --template-url="${TEMPLATE_URL}"
+
+# Alternative for Git repository:
+# pdk new module test_corporate_mirror --skip-interview \
+#   --template-ref="${TEMPLATE_REF}" \
+#   --template-branch="${TEMPLATE_BRANCH}"
+
+cd test_corporate_mirror
+
 pdk bundle install
 pdk bundle info puppet    # Expected: Puppet from corporate mirror
 pdk bundle info facter    # Expected: Facter from corporate mirror
 
-# Expected: corporate mirror is gem source for all gems
+# Verify corporate mirror usage
 cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
-```
-
-### Scenario 8: PDK Commands with Custom Sources
-
-Test that PDK commands work correctly with custom gem sources.
-
-```bash
-source ./clean_environment.sh
-export GEM_SOURCE_PUPPETCORE='https://rubygems-puppetcore.puppet.com'
-source ./set_puppetcore_authentication.sh
-
-# Test PDK functionality
-pdk bundle install
-pdk validate                    # Expected: Should work with custom puppet/facter
-pdk test unit                   # Expected: Should work with custom puppet/facter
-pdk new class example_class     # Expected: Should work with custom puppet/facter
 ```
 
 ### Finally do a clean reset
 
-Return to default state.
+Return to default state and clean up test modules.
 
 ```bash
+cd ~/pdk_gemfile_testing
 source ./clean_environment.sh
+
+# Optional: Clean up test modules
+# rm -rf new_module_tests update_module_tests
+```
+
+## Template Testing Workflows
+
+### Quick Template Verification
+
+To quickly verify the enhanced template is working:
+
+```bash
+# Check if enhanced features are present in generated Gemfile
+cd ~/pdk_gemfile_testing
+pdk new module quick_test --skip-interview \
+  --template-url="${TEMPLATE_URL}"
+
+# Alternative for Git repository:
+# pdk new module quick_test --skip-interview \
+#   --template-ref="${TEMPLATE_REF}" \
+#   --template-branch="${TEMPLATE_BRANCH}"
+
+cd quick_test
+
+# Look for enhanced features in Gemfile
+grep -n "gemsource_" Gemfile  # Should show gemsource_default and gemsource_puppetcore
+grep -n "location_for.*opts" Gemfile  # Should show enhanced location_for function
+grep -n "DEBUG_GEMS\|VERBOSE" Gemfile  # Should show debug functionality
+```
+
+### Template Comparison Testing
+
+Compare old vs new template behavior:
+
+```bash
+cd ~/pdk_gemfile_testing
+
+# Create module with default template
+pdk new module compare_default --skip-interview
+# Create module with enhanced template (local filesystem)
+pdk new module compare_enhanced --skip-interview \
+  --template-url="${TEMPLATE_URL}"
+
+# Alternative for Git repository:
+# pdk new module compare_enhanced --skip-interview \
+#   --template-ref="${TEMPLATE_REF}" \
+#   --template-branch="${TEMPLATE_BRANCH}"
+
+# Compare Gemfiles
+echo "=== Default Template Gemfile ==="
+head -20 compare_default/Gemfile
+
+echo "=== Enhanced Template Gemfile ==="
+head -20 compare_enhanced/Gemfile
+
+# Test both with same environment
+cd compare_default && pdk bundle install && cd ..
+cd compare_enhanced && pdk bundle install && cd ..
+
+# Compare bundle info
+echo "=== Default Template Bundle Info ==="
+cd compare_default && pdk bundle info puppet facter && cd ..
+
+echo "=== Enhanced Template Bundle Info ==="
+cd compare_enhanced && pdk bundle info puppet facter && cd ..
 ```
 
 ## Module Development Workflow Testing
@@ -258,16 +518,52 @@ cat Gemfile
 
 ## Expected Results Summary
 
-| Scenario | Puppet Source | Facter Source | Other Gems | Notes |
-|----------|---------------|---------------|------------|-------|
-| 1 | rubygems.org | rubygems.org | rubygems.org | Default public gems |
-| 2 | rubygems.org (specific) | rubygems.org (specific) | rubygems.org | Version constraints |
-| 3 | rubygems-puppetcore.puppet.com | rubygems-puppetcore.puppet.com | rubygems.org | Requires auth |
-| 4 | rubygems-puppetcore.puppet.com (specific) | rubygems-puppetcore.puppet.com (specific) | rubygems.org | Auth + versions |
-| 5 | git repository | git repository | rubygems.org | Development workflow |
-| 6 | local file path | rubygems.org | rubygems.org | Mixed sources |
-| 7 | corporate mirror | corporate mirror | corporate mirror | Corporate environment |
-| 8 | rubygems-puppetcore.puppet.com | rubygems-puppetcore.puppet.com | rubygems.org | PDK integration |
+| Scenario | Test Type | Puppet Source | Facter Source | Other Gems | Template Ref |
+|----------|-----------|---------------|---------------|------------|--------------|
+| 1 | New Module | rubygems.org | rubygems.org | rubygems.org | Enhanced |
+| 2 | New Module | rubygems-puppetcore.puppet.com | rubygems-puppetcore.puppet.com | rubygems.org | Enhanced |
+| 3 | New Module | git repository | git repository | rubygems.org | Enhanced |
+| 4 | Update | rubygems.org | rubygems.org | rubygems.org | Default→Enhanced |
+| 5 | Update | rubygems-puppetcore.puppet.com | rubygems-puppetcore.puppet.com | rubygems.org | Default→Enhanced |
+| 6 | New Module | rubygems.org (7.24.x) | rubygems.org (4.4.0) | rubygems.org | Enhanced |
+| 7 | New Module | local file path | rubygems.org | rubygems.org | Enhanced |
+| 8 | New Module | corporate mirror | corporate mirror | corporate mirror | Enhanced |
+
+## Template-Specific Testing Best Practices
+
+1. **Always specify template reference**: Use `--template-ref` and `--template-branch` for consistent testing
+2. **Test both new and update workflows**: Ensure enhanced template works in both scenarios
+3. **Verify template features**: Check generated Gemfile contains enhanced functions
+4. **Compare with default**: Test side-by-side with default template to verify improvements
+5. **Test environment isolation**: Use clean environments between tests
+6. **Document template versions**: Keep track of which template version/branch you're testing
+
+## Troubleshooting Template Issues
+
+### Template Not Found
+
+```bash
+# Verify template reference is correct
+git ls-remote "${TEMPLATE_REF}" "${TEMPLATE_BRANCH}"
+
+# Check PDK template cache
+pdk config get template_cache_dir
+# Clear cache if needed
+rm -rf $(pdk config get template_cache_dir)
+```
+
+### Template Not Applied
+
+```bash
+# Force template update (local filesystem)
+pdk update --force --template-url="${TEMPLATE_URL}"
+
+# Alternative for Git repository:
+# pdk update --force --template-ref="${TEMPLATE_REF}" --template-branch="${TEMPLATE_BRANCH}"
+
+# Verify Gemfile content
+grep -n "# For puppetcore" Gemfile  # Should be present in enhanced template
+```
 
 ## Module Testing Best Practices
 

--- a/docs/testing-pdk-module-gemfile-sources.md
+++ b/docs/testing-pdk-module-gemfile-sources.md
@@ -20,23 +20,9 @@ This flexibility is essential for development workflows, allowing modules to be 
 
 - Export a valid `PUPPET_FORGE_TOKEN` to enable access to puppetcore gems:
 
-Export a valid `PUPPET_FORGE_TOKEN` to enable access to puppetcore gems:
-
-```bash
-export PUPPET_FORGE_TOKEN=<VALID-LONG-TOKEN>
-```
-
-
-
-- Export some pdk template referencs
-
-```bash
-
-pdk new module test_default_gems --skip-interview --template-url="${TEMPLATE_URL}"
-```
-
-
-
+  ```bash
+  export PUPPET_FORGE_TOKEN=<VALID-LONG-TOKEN>
+  ```
 
 ### Helper scripts
 
@@ -91,14 +77,9 @@ source ~/pdk_gemfile_testing/clean_environment.sh
 
 # Create new module with enhanced template (local filesystem)
 rm -rf ~/pdk_gemfile_testing/new_module_tests/test_default_gems 
-pdk new module test_default_gems --skip-interview --template-url="${TEMPLATE_URL}"
+pdk new module test_default_gems --skip-interview --template-ref="${TEMPLATE_URL}"
 
-# Alternative for Git repository:
-# pdk new module test_default_gems --skip-interview \
-#   --template-ref="${TEMPLATE_REF}" \
-#   --template-branch="${TEMPLATE_BRANCH}"
-
-cd test_default_gems
+cd ~/pdk_gemfile_testing/new_module_tests/test_default_gems
 
 # Test gem installation and sources
 bundle install
@@ -107,11 +88,6 @@ bundle info facter    # Expected: Latest public facter version, e.g., 4.10.0 fro
 
 # Verify gem sources
 cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
-
-# Test PDK functionality
-pdk validate
-pdk new class example_class
-pdk test unit
 ```
 
 #### Scenario 2: Authenticated Puppetcore (New Module)
@@ -128,12 +104,7 @@ cd ~/pdk_gemfile_testing/new_module_tests
 rm -rf ~/pdk_gemfile_testing/new_module_tests/test_puppetcore_gems 
 pdk new module test_puppetcore_gems --skip-interview --template-url="${TEMPLATE_URL}"
 
-# Alternative for Git repository:
-# pdk new module test_puppetcore_gems --skip-interview \
-#   --template-ref="${TEMPLATE_REF}" \
-#   --template-branch="${TEMPLATE_BRANCH}"
-
-cd test_puppetcore_gems
+cd test_puppetcore_gems 
 
 # clean again before bundle install and set authentication
 source ~/pdk_gemfile_testing/clean_environment.sh
@@ -147,11 +118,6 @@ bundle info facter    # Expected: Latest puppetcore version, e.g., 4.14.0
 
 # Verify puppetcore sources
 cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
-
-# Test PDK functionality
-pdk validate
-pdk new class puppetcore_class
-pdk test unit
 ```
 
 #### Scenario 3: Git Repository Sources (New Module)
@@ -165,13 +131,8 @@ export PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet-private.git#main
 export FACTER_GEM_VERSION='https://github.com/puppetlabs/facter-private.git#main'
 
 # Create new module with enhanced template (local filesystem)
-rm -rf test_git_gems
+rm -rf ~/pdk_gemfile_testing/new_module_tests/test_git_gems
 pdk new module test_git_gems --skip-interview --template-url="${TEMPLATE_URL}"
-
-# Alternative for Git repository:
-# pdk new module test_git_gems --skip-interview \
-#   --template-ref="${TEMPLATE_REF}" \
-#   --template-branch="${TEMPLATE_BRANCH}"
 
 cd test_git_gems
 
@@ -185,10 +146,6 @@ bundle info facter    # Expected: Git version (e.g., '4.x.x 5554178')
 
 # Verify git sources
 cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
-
-# Test PDK functionality
-pdk validate
-pdk new class git_based_class
 ```
 
 ### `pdk update` scenarios
@@ -223,10 +180,6 @@ bundle info facter    # Expected: Git version (e.g., '4.x.x 5554178')
 
 # Verify git sources
 cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
-
-# Test PDK functionality
-pdk validate
-pdk new class git_based_class
 ```
 
 ### Clean up
@@ -238,7 +191,7 @@ cd ~/pdk_gemfile_testing
 source ./clean_environment.sh
 
 # Optional: Clean up test modules
-# rm -rf new_module_tests update_module_tests
+# rm -rf ~/pdk_gemfile_testing
 ```
 
 ## Appendix
@@ -246,38 +199,3 @@ source ./clean_environment.sh
 ### Why can't PDK use your bundled environment?
 
 PDK is designed as a self-contained tool with its own isolated Ruby and gem environment for consistency and reliability. In other words, the PDK has its own internal Puppet installation and doesn't automatically use the bundled Puppet version.  For example, when you run `pdk validate`, it will use PDK's internal Puppet version (e.g., 8.10.0) instead of your bundled version (e.g., 8.14.0 from puppetcore).
-
-### Template Reference Setup
-
-To test the enhanced Gemfile template, you have several options for referencing your template:
-
-- **Local filesystem**: Use `--template-url="${TEMPLATE_URL}"`
-- **Git repository**: Use `--template-ref="${TEMPLATE_REF}" --template-ref="${TEMPLATE_BRANCH}"`
-
-#### Option 1: Local Filesystem Path (Recommended for Development) ⭐
-
-PDK uses `--template-url` for local filesystem paths.  No branch parameter needed for local filesystem
-
-```bash
-# Use local filesystem path - much faster for iterative testing
-export TEMPLATE_URL="/Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/repositories/puppetlabs/pdk-templates"
-
-# OR alternatively with "file://" (some PDK versions prefer this)
-export TEMPLATE_URL="file:///Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/repositories/puppetlabs/pdk-templates"
-
-# create the new module
-pdk new module test_puppetcore_gems --skip-interview --template-url="${TEMPLATE_URL}"
-```
-
-Although `pdk new module` works fine with the above, the `pdk update` does not.  It requires both  `--template-ref`.
-
-#### Option 2: Git Repository Reference (Remote)
-
-```bash
-# Set template reference variables for your testing
-export TEMPLATE_URL="https://github.com/puppetlabs/pdk-templates.git"
-export TEMPLATE_REF="cat_2416_fix_pdk_templates_gemfile"  # Your feature branch
-
-# Alternative: Use specific commit hash if needed
-# export TEMPLATE_BRANCH="35f8fc1"  # Specific commit hash
-```

--- a/docs/testing-pdk-module-gemfile-sources.md
+++ b/docs/testing-pdk-module-gemfile-sources.md
@@ -1,0 +1,284 @@
+# Testing PDK Module Gemfile Sources
+
+## Description
+
+This guide shows you how to manually test all gem source scenarios for PDK modules using the enhanced Gemfile template. These tests validate real gem installation behavior across different sources: rubygems.org, authenticated puppetcore, git repositories, and local file paths when developing or testing Puppet modules with PDK.
+
+## Prerequisites
+
+- **PDK Installed**: Latest version of PDK (Puppet Development Kit)
+- **Puppet Forge Token**: Valid `PUPPET_FORGE_TOKEN` for authenticated scenarios
+- **Network Access**: Ability to reach rubygems.org and internal Puppet sources  
+- **Git Access**: SSH keys configured for private repository access
+- **Clean Environment**: No conflicting environment variables
+
+## Environment Setup
+
+### Create a Test Module
+
+Start by creating a new PDK module for testing:
+
+```bash
+# Create a test module
+pdk new module test_module_sources --skip-interview
+cd test_module_sources
+```
+
+### Create Helper Scripts
+
+Before running any scenarios, make sure to export `PUPPET_FORGE_TOKEN` with a valid token if you have access to puppetcore:
+
+```bash
+export PUPPET_FORGE_TOKEN=<VALID-LONG-TOKEN>
+```
+
+Then create reusable environment management scripts:
+
+```bash
+# Create environment cleanup script
+cat << 'EOF' > clean_environment.sh
+# Clean environment variables
+unset GEM_SOURCE GEM_SOURCE_PUPPETCORE
+unset PUPPET_GEM_VERSION FACTER_GEM_VERSION HIERA_GEM_VERSION  
+unset BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM
+# Clean bundler state
+rm -f Gemfile.lock && rm -rf vendor .bundle
+EOF
+chmod +x clean_environment.sh
+
+# Create puppetcore authentication script (if you have access)
+cat << 'EOF' > set_puppetcore_authentication.sh
+export BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM="forge-key:${PUPPET_FORGE_TOKEN}"
+EOF
+chmod +x set_puppetcore_authentication.sh
+```
+
+**Important**: Use `source ./script.sh` or `. ./script.sh` to execute these scripts.
+
+## Testing Scenarios
+
+### Scenario 1: Default Public RubyGems
+
+Test basic functionality with public rubygems.org as the default source.
+
+```bash
+source ./clean_environment.sh
+pdk bundle install
+pdk bundle info puppet    # Expected: Latest public puppet version, e.g., 8.10.0 from rubygems.org
+pdk bundle info facter    # Expected: Latest public facter version, e.g., 4.10.0 from rubygems.org
+
+# Expected: gem source for puppet and facter is rubygems.org
+cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
+```
+
+### Scenario 2: Default RubyGems with Specific Versions
+
+Test version constraints with public rubygems.org.
+
+```bash
+source ./clean_environment.sh
+export PUPPET_GEM_VERSION='~> 7.24.0'
+export FACTER_GEM_VERSION='= 4.4.0'
+pdk bundle install
+pdk bundle info puppet    # Expected: 7.24.x from rubygems.org
+pdk bundle info facter    # Expected: 4.4.0 from rubygems.org
+
+# Expected: gem source for puppet and facter is rubygems.org
+cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
+```
+
+### Scenario 3: Authenticated Puppetcore for puppet/facter
+
+Test authenticated puppetcore access (requires valid PUPPET_FORGE_TOKEN).
+
+```bash
+source ./clean_environment.sh
+source ./set_puppetcore_authentication.sh
+export GEM_SOURCE_PUPPETCORE='https://rubygems-puppetcore.puppet.com'
+pdk bundle install
+pdk bundle info puppet    # Expected: Latest puppetcore version from authenticated source
+pdk bundle info facter    # Expected: Latest puppetcore version from authenticated source
+
+# Expected: rubygems-puppetcore.puppet.com is gem source for both puppet and facter
+cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
+```
+
+### Scenario 4: Authenticated Puppetcore with Specific Versions
+
+Test version pinning with authenticated puppetcore sources.
+
+```bash
+source ./clean_environment.sh
+source ./set_puppetcore_authentication.sh
+export GEM_SOURCE_PUPPETCORE='https://rubygems-puppetcore.puppet.com'
+export PUPPET_GEM_VERSION='= 8.13.0'
+export FACTER_GEM_VERSION='= 4.13.0'
+pdk bundle install
+pdk bundle info puppet    # Expected: 8.13.0 from puppetcore
+pdk bundle info facter    # Expected: 4.13.0 from puppetcore
+
+# Expected: rubygems-puppetcore.puppet.com is gem source for both puppet and facter
+cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
+```
+
+### Scenario 5: Git Repository Sources
+
+Test development workflow with git repositories that override the existing gem sources.
+
+```bash
+source ./clean_environment.sh
+export PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#main'
+export FACTER_GEM_VERSION='https://github.com/puppetlabs/facter.git#main'
+pdk bundle install
+pdk bundle info puppet    # Expected: Git version (e.g., '8.x.x ab48604')
+pdk bundle info facter    # Expected: Git version (e.g., '4.x.x 5554178')
+
+# Expected: github repos are the gemsources for both puppet and facter
+cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
+```
+
+### Scenario 6: Mixed Local and Remote Sources
+
+Test facter from default source and puppet from local file path.
+
+```bash
+source ./clean_environment.sh
+
+# Clone local puppet for testing
+git clone https://github.com/puppetlabs/puppet.git tmp/puppet
+export PUPPET_GEM_VERSION="file:///${PWD}/tmp/puppet"
+pdk bundle install
+pdk bundle info puppet    # Expected: Local file path
+pdk bundle info facter    # Expected: Default source
+
+# Expected: file path gemsource for puppet and default gemsource for facter
+cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
+```
+
+### Scenario 7: Corporate Gem Source Override
+
+Test using a corporate gem mirror for all gems.
+
+```bash
+source ./clean_environment.sh
+export GEM_SOURCE='https://your-corporate-mirror.com/rubygems/'
+pdk bundle install
+pdk bundle info puppet    # Expected: Puppet from corporate mirror
+pdk bundle info facter    # Expected: Facter from corporate mirror
+
+# Expected: corporate mirror is gem source for all gems
+cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
+```
+
+### Scenario 8: PDK Commands with Custom Sources
+
+Test that PDK commands work correctly with custom gem sources.
+
+```bash
+source ./clean_environment.sh
+export GEM_SOURCE_PUPPETCORE='https://rubygems-puppetcore.puppet.com'
+source ./set_puppetcore_authentication.sh
+
+# Test PDK functionality
+pdk bundle install
+pdk validate                    # Expected: Should work with custom puppet/facter
+pdk test unit                   # Expected: Should work with custom puppet/facter
+pdk new class example_class     # Expected: Should work with custom puppet/facter
+```
+
+### Finally do a clean reset
+
+Return to default state.
+
+```bash
+source ./clean_environment.sh
+```
+
+## Module Development Workflow Testing
+
+### Testing with RSpec
+
+Test that RSpec works with different gem sources:
+
+```bash
+source ./clean_environment.sh
+export GEM_SOURCE_PUPPETCORE='https://rubygems-puppetcore.puppet.com'
+source ./set_puppetcore_authentication.sh
+
+pdk bundle install
+pdk new class example_class
+pdk test unit --verbose
+```
+
+### Testing with Different Puppet Versions
+
+Test module compatibility across Puppet versions:
+
+```bash
+# Test with Puppet 7.x
+source ./clean_environment.sh
+export PUPPET_GEM_VERSION='~> 7.24.0'
+pdk bundle install
+pdk validate
+
+# Test with Puppet 8.x
+source ./clean_environment.sh
+export PUPPET_GEM_VERSION='~> 8.10.0'
+pdk bundle install
+pdk validate
+```
+
+## Debugging
+
+### Enable Debug Output
+
+```bash
+DEBUG_GEMS=1 pdk bundle install
+# OR
+VERBOSE=1 pdk bundle install
+```
+
+This shows exactly which gem statements are generated by the enhanced Gemfile template.
+
+### Common Issues
+
+1. **Authentication failures**: Ensure `PUPPET_FORGE_TOKEN` is valid and `BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM` is set correctly
+2. **Network timeouts**: Check corporate firewall settings for rubygems.org access
+3. **Git access**: Verify SSH keys for private repositories
+4. **Version conflicts**: Use `pdk bundle exec gem dependency puppet` to check constraints
+5. **PDK cache issues**: Clear PDK cache with `rm -rf ~/.pdk/cache`
+
+### Inspecting Generated Gemfile
+
+To see what the actual Gemfile looks like after PDK processes the template:
+
+```bash
+cat Gemfile
+```
+
+## Expected Results Summary
+
+| Scenario | Puppet Source | Facter Source | Other Gems | Notes |
+|----------|---------------|---------------|------------|-------|
+| 1 | rubygems.org | rubygems.org | rubygems.org | Default public gems |
+| 2 | rubygems.org (specific) | rubygems.org (specific) | rubygems.org | Version constraints |
+| 3 | rubygems-puppetcore.puppet.com | rubygems-puppetcore.puppet.com | rubygems.org | Requires auth |
+| 4 | rubygems-puppetcore.puppet.com (specific) | rubygems-puppetcore.puppet.com (specific) | rubygems.org | Auth + versions |
+| 5 | git repository | git repository | rubygems.org | Development workflow |
+| 6 | local file path | rubygems.org | rubygems.org | Mixed sources |
+| 7 | corporate mirror | corporate mirror | corporate mirror | Corporate environment |
+| 8 | rubygems-puppetcore.puppet.com | rubygems-puppetcore.puppet.com | rubygems.org | PDK integration |
+
+## Module Testing Best Practices
+
+1. **Always test with clean environment**: Use the cleanup script between scenarios
+2. **Test PDK commands**: Ensure `pdk validate`, `pdk test unit`, and `pdk new` work correctly
+3. **Verify gem sources**: Always check `Gemfile.lock` to confirm expected sources
+4. **Test different Puppet versions**: Ensure your module works across supported versions
+5. **Check for conflicts**: Look for gem version conflicts in different scenarios
+
+## Related Documentation
+
+- [PDK Documentation](https://puppet.com/docs/pdk/latest/pdk.html) - Official PDK documentation
+- [Enhanced Gemfile Template](../moduleroot/Gemfile.erb) - The actual enhanced Gemfile template
+- [Puppet Module Development](https://puppet.com/docs/puppet/latest/modules_fundamentals.html) - Module development guide

--- a/docs/testing-pdk-module-gemfile-sources.md
+++ b/docs/testing-pdk-module-gemfile-sources.md
@@ -2,86 +2,36 @@
 
 ## Description
 
-This guide shows you how to manually test all gem source scenarios for PDK modules using the enhanced Gemfile template. These tests validate real gem installation behavior across different sources: rubygems.org, authenticated puppetcore, git repositories, and local file paths when developing or testing Puppet modules with PDK.
+This guide shows you how to manually test the `Gemfile` logic introduced by this PR <https://github.com/puppetlabs/pdk-templates/pull/621>.  These tests validate gem installation behavior by varying gemsources (public <https://rubygems.org>, private puppetcore <https://rubygems-puppetcore.puppet.com>, etc), and by replacing puppet/facter versions with git repositories, and local file paths.  Swapping in a file path reference to puppet, for example, is a good way develop and troubleshoot.
 
-**Key Testing Areas:**
+The scenarios focus on two areas:
 
-- `pdk new module` - Creating new modules with enhanced Gemfile template
-- `pdk update` - Updating existing modules to use enhanced Gemfile template  
-- Various gem source configurations and combinations
+- `pdk new module` - Can a new module swap in different gemsources and puppet/facter versions?
+- `pdk update` - Will an existing module convert to the new Gemfile ok?
 
-## Prerequisites
+## Setup
 
-- **PDK Installed**: Latest version of PDK (Puppet Development Kit)
-- **Puppet Forge Token**: Valid `PUPPET_FORGE_TOKEN` for authenticated scenarios
-- **Network Access**: Ability to reach rubygems.org and internal Puppet sources  
-- **Git Access**: SSH keys configured for private repository access
-- **Clean Environment**: No conflicting environment variables
-
-## Environment Setup
-
-### Testing Directory Structure
-
-Create a dedicated testing directory structure:
-
-```bash
-# Create testing workspace
-mkdir -p ~/pdk_gemfile_testing
-cd ~/pdk_gemfile_testing
-
-# We'll create modules here:
-# - new_module_tests/     (for pdk new module testing)
-# - update_module_tests/  (for pdk update testing) 
-```
-
-### Template Reference Setup
-
-To test the enhanced Gemfile template, you have several options for referencing your template:
-
-#### Option 1: Local Filesystem Path (Recommended for Development) ⭐
-
-```bash
-# Use local filesystem path - much faster for iterative testing
-export TEMPLATE_URL="/Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/repositories/puppetlabs/pdk-templates"
-
-# PDK uses --template-url for local filesystem paths
-# No branch parameter needed for local filesystem
-```
-
-#### Option 2: Git Repository Reference (Remote)
-
-```bash
-# Set template reference variables for your testing
-export TEMPLATE_REF="https://github.com/puppetlabs/pdk-templates.git"
-export TEMPLATE_BRANCH="cat_2416_fix_pdk_templates_gemfile"  # Your feature branch
-
-# Alternative: Use specific commit hash if needed
-# export TEMPLATE_BRANCH="35f8fc1"  # Specific commit hash
-```
-
-#### Option 3: File URL Format
-
-```bash
-# Alternative file URL format (some PDK versions prefer this)
-export TEMPLATE_URL="file:///Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/repositories/puppetlabs/pdk-templates"
-```
-
-**Recommendation**: Use Option 1 (local filesystem path) for development and testing as it's much faster and doesn't require network access or git operations.
-
-#### PDK Command Differences
-
-- **Local filesystem**: Use `--template-url="${TEMPLATE_URL}"`
-- **Git repository**: Use `--template-ref="${TEMPLATE_REF}" --template-branch="${TEMPLATE_BRANCH}"`
-
-### Create Helper Scripts
-
-Before running any scenarios, make sure to export `PUPPET_FORGE_TOKEN` with a valid token if you have access to puppetcore:
+Export a valid `PUPPET_FORGE_TOKEN` to enable access to puppetcore gems:
 
 ```bash
 export PUPPET_FORGE_TOKEN=<VALID-LONG-TOKEN>
 ```
 
-Then create reusable environment management scripts:
+Create a local directory for testing:
+
+```bash
+# Create testing workspace
+mkdir -p ~/pdk_gemfile_testing/{new_module_tests,update_module_tests}
+cd ~/pdk_gemfile_testing
+```
+
+Export a valid `PUPPET_FORGE_TOKEN` to enable access to puppetcore gems:
+
+```bash
+export PUPPET_FORGE_TOKEN=<VALID-LONG-TOKEN>
+```
+
+Create reusable environment management scripts.  Each scenario can now be setup accurately and quickly.
 
 ```bash
 # Create environment cleanup script
@@ -102,11 +52,11 @@ EOF
 chmod +x set_puppetcore_authentication.sh
 ```
 
-**Important**: Use `source ./script.sh` or `. ./script.sh` to execute these scripts.
+**Important**: Use `source ./script.sh` or `. ./script.sh` to execute these scripts otherwise the environment variables may not get registered on your terminal session.
 
 ## Testing Scenarios
 
-### Phase 1: PDK New Module Testing
+### Verifying `pdk new module`
 
 Create new modules using the enhanced Gemfile template to test initial setup scenarios.
 
@@ -221,7 +171,7 @@ pdk validate
 pdk new class git_based_class
 ```
 
-### Phase 2: PDK Update Testing
+### Verifying `pdk update`
 
 Test updating existing modules to use the enhanced Gemfile template.
 
@@ -235,144 +185,28 @@ mkdir -p update_module_tests && cd update_module_tests
 source ~/pdk_gemfile_testing/clean_environment.sh
 
 # Create module with default PDK template first
-pdk new module test_update_module --skip-interview
+# pdk new module test_update_module --skip-interview
+git clone https://github.com/puppetlabs/puppetlabs-motd.git
 
-cd test_update_module
+cd puppetlabs-motd
 
-# Check initial Gemfile (should be standard template)
-echo "=== Initial Gemfile content ==="
-cat Gemfile
+# Update using --template-ref, e.g.,
+pdk update --template-ref=https://github.com/puppetlabs/pdk-templates --template-ref=cat_2416_fix_pdk_templates_gemfile  
 
-# Update to enhanced template (local filesystem)
-pdk update --template-url="${TEMPLATE_URL}"
+export PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet-private.git#main'
 
-# Alternative for Git repository:
-# pdk update --template-ref="${TEMPLATE_REF}" --template-branch="${TEMPLATE_BRANCH}"
+# Test gem installation from git sources
+rm -rf Gemfile.lock vendor
+bundle install
+bundle info puppet    # Expected: Git version (e.g., '8.x.x ab48604')
+bundle info facter    # Expected: Git version (e.g., '4.x.x 5554178')
 
-# Check updated Gemfile (should now have enhanced features)
-echo "=== Updated Gemfile content ==="
-cat Gemfile
+# Verify git sources
+cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
 
-# Test functionality with enhanced template
-pdk bundle install
+# Test PDK functionality
 pdk validate
-pdk test unit
-```
-
-#### Scenario 5: Update with Custom Gem Sources
-
-Update existing module and test with custom gem sources.
-
-```bash
-cd ~/pdk_gemfile_testing/update_module_tests
-source ~/pdk_gemfile_testing/clean_environment.sh
-source ~/pdk_gemfile_testing/set_puppetcore_authentication.sh
-export GEM_SOURCE_PUPPETCORE='https://rubygems-puppetcore.puppet.com'
-
-# Create standard module
-pdk new module test_update_with_sources --skip-interview
-cd test_update_with_sources
-
-# Update to enhanced template (local filesystem)
-pdk update --template-url="${TEMPLATE_URL}"
-
-# Alternative for Git repository:
-# pdk update --template-ref="${TEMPLATE_REF}" --template-branch="${TEMPLATE_BRANCH}"
-
-# Test with custom sources
-pdk bundle install
-pdk bundle info puppet    # Expected: puppetcore version
-pdk bundle info facter    # Expected: puppetcore version
-
-# Verify sources
-cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
-```
-
-### Phase 3: Legacy Scenarios (Backwards Compatibility)
-
-#### Scenario 6: Version-Specific Testing
-
-Test version constraints work correctly with enhanced template.
-
-```bash
-cd ~/pdk_gemfile_testing/new_module_tests
-source ~/pdk_gemfile_testing/clean_environment.sh
-export PUPPET_GEM_VERSION='~> 7.24.0'
-export FACTER_GEM_VERSION='= 4.4.0'
-
-pdk new module test_version_constraints --skip-interview \
-  --template-url="${TEMPLATE_URL}"
-
-# Alternative for Git repository:
-# pdk new module test_version_constraints --skip-interview \
-#   --template-ref="${TEMPLATE_REF}" \
-#   --template-branch="${TEMPLATE_BRANCH}"
-
-cd test_version_constraints
-
-pdk bundle install
-pdk bundle info puppet    # Expected: 7.24.x from rubygems.org
-pdk bundle info facter    # Expected: 4.4.0 from rubygems.org
-
-# Verify version constraints work
-cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
-```
-
-#### Scenario 7: Mixed Local and Remote Sources
-
-Test combination of local file paths and remote sources.
-
-```bash
-cd ~/pdk_gemfile_testing/new_module_tests
-source ~/pdk_gemfile_testing/clean_environment.sh
-
-# Clone local puppet for testing
-git clone https://github.com/puppetlabs/puppet.git tmp/puppet
-export PUPPET_GEM_VERSION="file:///${PWD}/tmp/puppet"
-
-pdk new module test_mixed_sources --skip-interview \
-  --template-url="${TEMPLATE_URL}"
-
-# Alternative for Git repository:
-# pdk new module test_mixed_sources --skip-interview \
-#   --template-ref="${TEMPLATE_REF}" \
-#   --template-branch="${TEMPLATE_BRANCH}"
-
-cd test_mixed_sources
-
-pdk bundle install
-pdk bundle info puppet    # Expected: Local file path
-pdk bundle info facter    # Expected: Default source
-
-# Verify mixed sources
-cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
-```
-
-#### Scenario 8: Corporate Gem Source Override
-
-Test using a corporate gem mirror for all gems.
-
-```bash
-cd ~/pdk_gemfile_testing/new_module_tests
-source ~/pdk_gemfile_testing/clean_environment.sh
-export GEM_SOURCE='https://your-corporate-mirror.com/rubygems/'
-
-pdk new module test_corporate_mirror --skip-interview \
-  --template-url="${TEMPLATE_URL}"
-
-# Alternative for Git repository:
-# pdk new module test_corporate_mirror --skip-interview \
-#   --template-ref="${TEMPLATE_REF}" \
-#   --template-branch="${TEMPLATE_BRANCH}"
-
-cd test_corporate_mirror
-
-pdk bundle install
-pdk bundle info puppet    # Expected: Puppet from corporate mirror
-pdk bundle info facter    # Expected: Facter from corporate mirror
-
-# Verify corporate mirror usage
-cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
+pdk new class git_based_class
 ```
 
 ### Finally do a clean reset
@@ -387,371 +221,45 @@ source ./clean_environment.sh
 # rm -rf new_module_tests update_module_tests
 ```
 
-## Template Testing Workflows
+## Appendix
 
-### Quick Template Verification
+### Why can't PDK use your bundled environment?
 
-To quickly verify the enhanced template is working:
+PDK is designed as a self-contained tool with its own isolated Ruby and gem environment for consistency and reliability. In other words, the PDK has its own internal Puppet installation and doesn't automatically use the bundled Puppet version.  For example, when you run `pdk validate`, it will use PDK's internal Puppet version (e.g., 8.10.0) instead of your bundled version (e.g., 8.14.0 from puppetcore).
 
-```bash
-# Check if enhanced features are present in generated Gemfile
-cd ~/pdk_gemfile_testing
-pdk new module quick_test --skip-interview \
-  --template-url="${TEMPLATE_URL}"
+### Template Reference Setup
 
-# Alternative for Git repository:
-# pdk new module quick_test --skip-interview \
-#   --template-ref="${TEMPLATE_REF}" \
-#   --template-branch="${TEMPLATE_BRANCH}"
+To test the enhanced Gemfile template, you have several options for referencing your template:
 
-cd quick_test
+- **Local filesystem**: Use `--template-url="${TEMPLATE_URL}"`
+- **Git repository**: Use `--template-ref="${TEMPLATE_REF}" --template-ref="${TEMPLATE_BRANCH}"`
 
-# Look for enhanced features in Gemfile
-grep -n "gemsource_" Gemfile  # Should show gemsource_default and gemsource_puppetcore
-grep -n "location_for.*opts" Gemfile  # Should show enhanced location_for function
-grep -n "DEBUG_GEMS\|VERBOSE" Gemfile  # Should show debug functionality
-```
+#### Option 1: Local Filesystem Path (Recommended for Development) ⭐
 
-### Template Comparison Testing
-
-Compare old vs new template behavior:
+PDK uses `--template-url` for local filesystem paths.  No branch parameter needed for local filesystem
 
 ```bash
-cd ~/pdk_gemfile_testing
+# Use local filesystem path - much faster for iterative testing
+export TEMPLATE_URL="/Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/repositories/puppetlabs/pdk-templates"
 
-# Create module with default template
-pdk new module compare_default --skip-interview
-# Create module with enhanced template (local filesystem)
-pdk new module compare_enhanced --skip-interview \
-  --template-url="${TEMPLATE_URL}"
+# OR alternatively with "file://" (some PDK versions prefer this)
+export TEMPLATE_URL="file:///Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/repositories/puppetlabs/pdk-templates"
 
-# Alternative for Git repository:
-# pdk new module compare_enhanced --skip-interview \
-#   --template-ref="${TEMPLATE_REF}" \
-#   --template-branch="${TEMPLATE_BRANCH}"
-
-# Compare Gemfiles
-echo "=== Default Template Gemfile ==="
-head -20 compare_default/Gemfile
-
-echo "=== Enhanced Template Gemfile ==="
-head -20 compare_enhanced/Gemfile
-
-# Test both with same environment
-cd compare_default && pdk bundle install && cd ..
-cd compare_enhanced && pdk bundle install && cd ..
-
-# Compare bundle info
-echo "=== Default Template Bundle Info ==="
-cd compare_default && pdk bundle info puppet facter && cd ..
-
-echo "=== Enhanced Template Bundle Info ==="
-cd compare_enhanced && pdk bundle info puppet facter && cd ..
+# create the new module
+pdk new module test_puppetcore_gems --skip-interview --template-url="${TEMPLATE_URL}"
 ```
 
-## Module Development Workflow Testing
+Although `pdk new module` works fine with the above, the `pdk update` does not.  It requires both  `--template-ref`.
 
-### Testing with RSpec
-
-Test that RSpec works with different gem sources:
+#### Option 2: Git Repository Reference (Remote)
 
 ```bash
-source ./clean_environment.sh
-export GEM_SOURCE_PUPPETCORE='https://rubygems-puppetcore.puppet.com'
-source ./set_puppetcore_authentication.sh
+# Set template reference variables for your testing
+export TEMPLATE_URL="https://github.com/puppetlabs/pdk-templates.git"
+export TEMPLATE_REF="cat_2416_fix_pdk_templates_gemfile"  # Your feature branch
 
-pdk bundle install
-pdk new class example_class
-pdk test unit --verbose
+# Alternative: Use specific commit hash if needed
+# export TEMPLATE_BRANCH="35f8fc1"  # Specific commit hash
 ```
 
-### Testing with Different Puppet Versions
-
-Test module compatibility across Puppet versions:
-
-```bash
-# Test with Puppet 7.x
-source ./clean_environment.sh
-export PUPPET_GEM_VERSION='~> 7.24.0'
-pdk bundle install
-pdk validate
-
-# Test with Puppet 8.x
-source ./clean_environment.sh
-export PUPPET_GEM_VERSION='~> 8.10.0'
-pdk bundle install
-pdk validate
-```
-
-## Using PDK with Bundled Environment
-
-### Important: PDK Version Behavior
-
-PDK has its own internal Puppet installation and doesn't automatically use the bundled Puppet version. When you run `pdk validate`, it will use PDK's internal Puppet version (e.g., 8.10.0) instead of your bundled version (e.g., 8.14.0 from puppetcore).
-
-**Why can't PDK use your bundled environment?**
-
-PDK is designed as a self-contained tool with its own isolated Ruby and gem environment for consistency and reliability. Attempting to run `bundle exec pdk` will fail with bundler version conflicts and missing native extensions because:
-
-1. **PDK uses its own Ruby**: `/opt/puppetlabs/pdk/private/ruby/3.2.5/`
-2. **PDK expects specific bundler version**: e.g., `bundler (= 2.6.9)`
-3. **Your bundle has different versions**: This creates incompatible environments
-4. **Native gem extensions**: PDK can't access system gems compiled for your Ruby
-
-### Solution: Use Bundle Exec for Validation
-
-To ensure you're testing with the correct Puppet version from your bundle, use individual validation tools through `bundle exec`:
-
-```bash
-# ✅ CORRECT: Use bundle exec to test with bundled Puppet version
-cd test_puppetcore_gems
-
-# 1. Verify you have the correct bundled version
-bundle info puppet    # Should show 8.14.0 from puppetcore
-
-# 2. Create content to test
-pdk new class example_class
-
-# 3. Validate using bundled Puppet version (8.14.0)
-bundle exec puppet parser validate manifests/example_class.pp
-bundle exec puppet-lint manifests/
-bundle exec rspec spec/
-
-# 4. PDK generation commands still work (these use PDK's internal Puppet)
-pdk new class another_class  # Uses PDK's Puppet 8.10.0 for generation
-pdk new defined_type my_type # Uses PDK's Puppet 8.10.0 for generation
-```
-
-### What Works With Each Approach
-
-| Command | Puppet Version Used | Purpose |
-|---------|-------------------|---------|
-| `pdk validate` | PDK's internal (8.10.0) | ❌ Won't use your bundled gems |
-| `bundle exec pdk` | **DOES NOT WORK** | ❌ PDK has its own Ruby environment |
-| `bundle exec puppet parser validate` | Bundled (8.14.0) | ✅ Uses your specific Puppet version |
-| `bundle exec puppet-lint` | Bundled environment | ✅ Uses bundled gems |
-| `bundle exec rspec` | Bundled (8.14.0) | ✅ Tests with correct Puppet version |
-| `pdk new class` | PDK's internal (8.10.0) | ✅ Code generation works fine |
-| `pdk bundle install` | N/A | ✅ Installs your specified gems |
-
-**Important**: `bundle exec pdk` does not work because PDK has its own isolated Ruby/gem environment with specific bundler version requirements. You must run PDK commands directly (e.g., `pdk new class`) and use `bundle exec` only for individual validation tools (e.g., `bundle exec puppet`, `bundle exec rspec`).
-
-### Example: Complete Testing Workflow
-
-```bash
-# After setting up puppetcore authentication and running pdk bundle install
-
-# 1. Verify correct versions are installed
-bundle info puppet    # Expected: 8.14.0 from puppetcore
-bundle info facter    # Expected: 4.14.0 from puppetcore
-
-# 2. Create test content
-pdk new class test_class
-
-# 3. Test with correct Puppet version
-echo "Testing with bundled Puppet $(bundle exec puppet --version):"
-bundle exec puppet parser validate manifests/test_class.pp
-bundle exec puppet-lint manifests/test_class.pp
-
-# 4. Run spec tests with correct version
-bundle exec rspec spec/classes/test_class_spec.rb
-
-# 5. Check that you're using the right gems
-echo "Verification - sources from Gemfile.lock:"
-cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
-```
-
-This approach ensures you're actually testing your module with the specific Puppet and Facter versions from your chosen gem source (puppetcore, git, etc.) rather than PDK's default versions.
-
-## Advanced PDK Workarounds
-
-### Can I Force PDK to Use My Bundled Environment?
-
-**Short answer**: No, not reliably.
-
-**Long answer**: PDK is intentionally designed as a self-contained tool. While there are some experimental approaches, they're not recommended for production use:
-
-#### Attempted Workaround 1: Bundle Exec PDK (Fails)
-
-```bash
-# ❌ THIS DOES NOT WORK
-bundle exec pdk validate
-
-# Results in errors like:
-# Could not find gem 'bundler (= 2.6.9)' with executable bundle
-# Could not find racc-1.8.1, prism-1.4.0, nkf-0.2.0, bigdecimal-3.2.2, io-console-0.8.1
-```
-
-#### Attempted Workaround 2: Gem Path Override (Unreliable)
-
-```bash
-# ❌ EXPERIMENTAL - May break PDK functionality
-GEM_PATH="$(bundle config path)/ruby/$(ruby -e 'puts RUBY_VERSION')" pdk validate
-```
-
-This may work sometimes but can cause unpredictable failures.
-
-#### Attempted Workaround 3: Symlink Approach (Complex)
-
-Some users create symlinks from PDK's gem directory to their bundled gems, but this:
-
-- Requires admin access to PDK installation
-- Breaks when PDK updates
-- Can cause version conflicts
-- Is not officially supported
-
-### Recommended Approach: Hybrid Workflow
-
-**Best practice**: Use PDK and bundle exec together strategically:
-
-```bash
-# ✅ Use PDK for what it's good at
-pdk new module my_module                    # Module generation
-pdk new class my_class                      # Code generation  
-pdk new defined_type my_type               # Code scaffolding
-pdk update                                 # Template updates
-
-# ✅ Use bundle exec for validation with your specific versions
-bundle exec puppet parser validate manifests/*.pp
-bundle exec puppet-lint manifests/ 
-bundle exec rspec spec/
-bundle exec rubocop
-
-# ✅ Use bundle exec for specific gem information
-bundle info puppet                         # Check actual version installed
-bundle exec puppet --version              # Verify version used
-```
-
-### When This Matters Most
-
-This hybrid approach is especially important when:
-
-1. **Testing with puppetcore gems** - You need to validate against internal Puppet versions
-2. **Testing with git branches** - You're testing unreleased Puppet features
-3. **Corporate environments** - You have specific gem source requirements
-4. **Version-specific testing** - You need to test against exact Puppet versions
-5. **CI/CD pipelines** - You need reproducible, exact version testing
-
-### Alternative: Custom Validation Script
-
-Create a custom script that mimics `pdk validate` but uses your bundled environment:
-
-```bash
-# Create custom_validate.sh
-cat << 'EOF' > custom_validate.sh
-#!/bin/bash
-echo "🔍 Custom validation using bundled Puppet $(bundle exec puppet --version)"
-
-echo "📝 Puppet syntax validation..."
-find manifests -name "*.pp" -exec bundle exec puppet parser validate {} \;
-
-echo "🎨 Puppet-lint validation..."
-bundle exec puppet-lint manifests/
-
-echo "🧪 RSpec tests..."
-bundle exec rspec spec/
-
-echo "💎 Ruby style validation..."
-bundle exec rubocop
-
-echo "✅ All validations complete!"
-EOF
-
-chmod +x custom_validate.sh
-
-# Use your custom validator
-./custom_validate.sh
-```
-
-This gives you the validation functionality of `pdk validate` but using your bundled environment.
-
-## Debugging
-
-### Enable Debug Output
-
-```bash
-DEBUG_GEMS=1 pdk bundle install
-# OR
-VERBOSE=1 pdk bundle install
-```
-
-This shows exactly which gem statements are generated by the enhanced Gemfile template.
-
-### Common Issues
-
-1. **Authentication failures**: Ensure `PUPPET_FORGE_TOKEN` is valid and `BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM` is set correctly
-2. **Network timeouts**: Check corporate firewall settings for rubygems.org access
-3. **Git access**: Verify SSH keys for private repositories
-4. **Version conflicts**: Use `pdk bundle exec gem dependency puppet` to check constraints
-5. **PDK cache issues**: Clear PDK cache with `rm -rf ~/.pdk/cache`
-
-### Inspecting Generated Gemfile
-
-To see what the actual Gemfile looks like after PDK processes the template:
-
-```bash
-cat Gemfile
-```
-
-## Expected Results Summary
-
-| Scenario | Test Type | Puppet Source | Facter Source | Other Gems | Template Ref |
-|----------|-----------|---------------|---------------|------------|--------------|
-| 1 | New Module | rubygems.org | rubygems.org | rubygems.org | Enhanced |
-| 2 | New Module | rubygems-puppetcore.puppet.com | rubygems-puppetcore.puppet.com | rubygems.org | Enhanced |
-| 3 | New Module | git repository | git repository | rubygems.org | Enhanced |
-| 4 | Update | rubygems.org | rubygems.org | rubygems.org | Default→Enhanced |
-| 5 | Update | rubygems-puppetcore.puppet.com | rubygems-puppetcore.puppet.com | rubygems.org | Default→Enhanced |
-| 6 | New Module | rubygems.org (7.24.x) | rubygems.org (4.4.0) | rubygems.org | Enhanced |
-| 7 | New Module | local file path | rubygems.org | rubygems.org | Enhanced |
-| 8 | New Module | corporate mirror | corporate mirror | corporate mirror | Enhanced |
-
-## Template-Specific Testing Best Practices
-
-1. **Always specify template reference**: Use `--template-ref` and `--template-branch` for consistent testing
-2. **Test both new and update workflows**: Ensure enhanced template works in both scenarios
-3. **Verify template features**: Check generated Gemfile contains enhanced functions
-4. **Compare with default**: Test side-by-side with default template to verify improvements
-5. **Test environment isolation**: Use clean environments between tests
-6. **Document template versions**: Keep track of which template version/branch you're testing
-
-## Troubleshooting Template Issues
-
-### Template Not Found
-
-```bash
-# Verify template reference is correct
-git ls-remote "${TEMPLATE_REF}" "${TEMPLATE_BRANCH}"
-
-# Check PDK template cache
-pdk config get template_cache_dir
-# Clear cache if needed
-rm -rf $(pdk config get template_cache_dir)
-```
-
-### Template Not Applied
-
-```bash
-# Force template update (local filesystem)
-pdk update --force --template-url="${TEMPLATE_URL}"
-
-# Alternative for Git repository:
-# pdk update --force --template-ref="${TEMPLATE_REF}" --template-branch="${TEMPLATE_BRANCH}"
-
-# Verify Gemfile content
-grep -n "# For puppetcore" Gemfile  # Should be present in enhanced template
-```
-
-## Module Testing Best Practices
-
-1. **Always test with clean environment**: Use the cleanup script between scenarios
-2. **Test PDK commands**: Ensure `pdk validate`, `pdk test unit`, and `pdk new` work correctly
-3. **Verify gem sources**: Always check `Gemfile.lock` to confirm expected sources
-4. **Test different Puppet versions**: Ensure your module works across supported versions
-5. **Check for conflicts**: Look for gem version conflicts in different scenarios
-
-## Related Documentation
-
-- [PDK Documentation](https://puppet.com/docs/pdk/latest/pdk.html) - Official PDK documentation
-- [Enhanced Gemfile Template](../moduleroot/Gemfile.erb) - The actual enhanced Gemfile template
-- [Puppet Module Development](https://puppet.com/docs/puppet/latest/modules_fundamentals.html) - Module development guide
+#### PDK Command Differences

--- a/docs/testing-pdk-module-gemfile-sources.md
+++ b/docs/testing-pdk-module-gemfile-sources.md
@@ -134,6 +134,7 @@ mkdir -p new_module_tests && cd new_module_tests
 source ~/pdk_gemfile_testing/clean_environment.sh
 
 # Create new module with enhanced template (local filesystem)
+rm -rf ~/pdk_gemfile_testing/new_module_tests/test_default_gems 
 pdk new module test_default_gems --skip-interview --template-url="${TEMPLATE_URL}"
 
 # Alternative for Git repository:
@@ -144,9 +145,9 @@ pdk new module test_default_gems --skip-interview --template-url="${TEMPLATE_URL
 cd test_default_gems
 
 # Test gem installation and sources
-pdk bundle install
-pdk bundle info puppet    # Expected: Latest public puppet version, e.g., 8.10.0 from rubygems.org
-pdk bundle info facter    # Expected: Latest public facter version, e.g., 4.10.0 from rubygems.org
+bundle install
+bundle info puppet    # Expected: Latest public puppet version, e.g., 8.10.0 from rubygems.org
+bundle info facter    # Expected: Latest public facter version, e.g., 4.10.0 from rubygems.org
 
 # Verify gem sources
 cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'
@@ -204,12 +205,12 @@ Create a new module and test with git-based gem sources.
 ```bash
 cd ~/pdk_gemfile_testing/new_module_tests
 source ~/pdk_gemfile_testing/clean_environment.sh
-export PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#main'
-export FACTER_GEM_VERSION='https://github.com/puppetlabs/facter.git#main'
+export PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet-private.git#main'
+export FACTER_GEM_VERSION='https://github.com/puppetlabs/facter-private.git#main'
 
 # Create new module with enhanced template (local filesystem)
-pdk new module test_git_gems --skip-interview \
-  --template-url="${TEMPLATE_URL}"
+rm -rf test_git_gems
+pdk new module test_git_gems --skip-interview --template-url="${TEMPLATE_URL}"
 
 # Alternative for Git repository:
 # pdk new module test_git_gems --skip-interview \
@@ -218,10 +219,13 @@ pdk new module test_git_gems --skip-interview \
 
 cd test_git_gems
 
+# remove Gemfile and vendor because the pdk creates the module with a different lock file
+rm -rf Gemfile.lock vendor
+
 # Test gem installation from git sources
-pdk bundle install
-pdk bundle info puppet    # Expected: Git version (e.g., '8.x.x ab48604')
-pdk bundle info facter    # Expected: Git version (e.g., '4.x.x 5554178')
+bundle install
+bundle info puppet    # Expected: Git version (e.g., '8.x.x ab48604')
+bundle info facter    # Expected: Git version (e.g., '4.x.x 5554178')
 
 # Verify git sources
 cat Gemfile.lock | ruby -ne 'puts $_ if $_ =~ /remote:|^\s{4}(puppet|facter)\s\(/'

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -56,18 +56,34 @@ def gem_spec(gem, max_len)
   output
 end
 -%>
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+# For puppetcore, set GEM_SOURCE_PUPPETCORE = 'https://rubygems-puppetcore.puppet.com'
+gemsource_default = ENV['GEM_SOURCE'] || 'https://rubygems.org'
+gemsource_puppetcore = ENV['GEM_SOURCE_PUPPETCORE'] || gemsource_default
+source gemsource_default
 
-def location_for(place_or_version, fake_version = nil)
-  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
-  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
+def location_for(place_or_constraint, fake_constraint = nil, opts = {})
+  git_url_regex  = /\A(?<url>(?:https?|git)[:@][^#]*)(?:#(?<branch>.*))?/
+  file_url_regex = %r{\Afile://(?<path>.*)}
 
-  if place_or_version && (git_url = place_or_version.match(git_url_regex))
-    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
-  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
-    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+  if place_or_constraint && (git_url = place_or_constraint.match(git_url_regex))
+    # Git source → ignore :source, keep fake_constraint
+    [fake_constraint, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
+
+  elsif place_or_constraint && (file_url = place_or_constraint.match(file_url_regex))
+    # File source → ignore :source, keep fake_constraint or default >= 0
+    [fake_constraint || '>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+
   else
-    [place_or_version, { require: false }]
+    # Plain version constraint → merge opts (including :source if provided)
+    [place_or_constraint, { require: false }.merge(opts)]
+  end
+end
+
+# Print debug information if DEBUG_GEMS or VERBOSE is set
+def print_gem_statement_for(gems)
+  puts 'DEBUG: Gem definitions that will be generated:'
+  gems.each do |gem_name, gem_params|
+    puts "DEBUG:   gem #{([gem_name.inspect] + gem_params.map(&:inspect)).join(', ')}"
   end
 end
 
@@ -109,18 +125,12 @@ puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
 facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
 hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
-# If PUPPET_FORGE_TOKEN is set then use authenticated source for both puppet and facter, since facter is a transitive dependency of puppet
-# Otherwise, do as before and use location_for to fetch gems from the default source
-if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gems['puppet'] = ['~> 8.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
-  gems['facter'] = ['~> 4.11', { require: false, source: 'https://rubygems-puppetcore.puppet.com' }]
-else
-  gems['puppet'] = location_for(puppet_version)
-  gems['facter'] = location_for(facter_version) if facter_version
-end
-
+gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
+gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
 gems['hiera'] = location_for(hiera_version) if hiera_version
 
+# Generate the gem definitions
+print_gem_statement_for(gems) if ENV['DEBUG_GEMS'] || ENV['VERBOSE']
 gems.each do |gem_name, gem_params|
   gem gem_name, *gem_params
 end
@@ -128,12 +138,14 @@ end
 # Evaluate Gemfile.local and ~/.gemfile if they exist
 extra_gemfiles = [
   "#{__FILE__}.local",
-  File.join(Dir.home, '.gemfile'),
+  File.join(Dir.home, '.gemfile')
 ]
 
 extra_gemfiles.each do |gemfile|
-  if File.file?(gemfile) && File.readable?(gemfile)
-    eval(File.read(gemfile), binding)
-  end
+  next unless File.file?(gemfile) && File.readable?(gemfile)
+
+  # rubocop:disable Security/Eval
+  eval(File.read(gemfile), binding)
+  # rubocop:enable Security/Eval
 end
 # vim: syntax=ruby

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <%
 def gem_length(gem)
   if gem['version']
@@ -127,10 +129,10 @@ hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
 gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
 gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
-gems['hiera'] = location_for(hiera_version) if hiera_version
+gems['hiera'] = location_for(hiera_version, nil, {}) if hiera_version
 
 # Generate the gem definitions
-print_gem_statement_for(gems) if ENV['DEBUG_GEMS'] || ENV['VERBOSE']
+print_gem_statement_for(gems) if ENV['DEBUG']
 gems.each do |gem_name, gem_params|
   gem gem_name, *gem_params
 end


### PR DESCRIPTION
# (CAT-2416) Enhance PDK Gemfile Template to Support Flexible Source Testing

## Overview

This PR introduces a significantly enhanced Gemfile.erb for that provides flexible, multi-source gem management capabilities for all pdk modules. The new system addresses development and deployment challenges by supporting multiple gem sources, environment-driven configuration, and comprehensive testing scenarios.

## Key features of this PR

* **Environment-Driven Configuration**.  The new Gemfile uses environment variables (`GEM_SOURCE` and `GEM_SOURCE_PUPPETCORE`) to configure gem sources, enabling the same file to work across multiple gem sources.

* **Improved `location_for` method** handles not only unique puppet and facter sources (git, https, file:, etc) but also different gemsources too.  For example, at the same time as pull facter from artifactory or rubygems-puppetcore, you can setup puppet to source from a local filesystem.

## Testing and Validation

**Manual Testing:** All scenarios are described in the manual testing document: [developer-docs/testing-gemfile-sources.md](https://github.com/puppetlabs/bolt-private/blob/cc03219f7ca7166f83b7c4145325985d116a17f9/developer-docs/testing-gemfile-sources.md).  **All of these have passed** and some of the results are below in the comments as proof.

### Backward Compatibility

The enhancement maintains full backward compatibility because by default all gems are pulled from Artifactory.

