### PR TITLE
(CAT-2564) Restrict rubocop-ast to ruby based parser

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -566,6 +566,12 @@ Gemfile:
         version: '~> 2.27.0'
       - gem: 'rubocop-capybara'
         version: '~> 2.22.0'
+      - gem: 'rubocop-ast'
+        version: '< 1.43.0'
+        platforms:
+          - mswin
+          - mingw
+          - x64_mingw
       - gem: 'rb-readline'
         version: '= 0.5.5'
         platforms:


### PR DESCRIPTION
rubocop-ast added a runtime dependency to prism in 1.43.0[1] Prism contains a native extension, so it requires a compiler to install. Many gems with native extensions like ffi, ship platform-specific gems with precompiled extensions to rubygems.org, but prism doesn't. So on Windows, pin to an older version of rubocop-ast. We should probably add prism to the pdk-runtime as more gems are relying on it and remove this pin.

    Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory:
    C:/ProgramFiles64Folder/PuppetLabs/DevelopmentKit/private/ruby/3.2.10/lib/ruby/gems/3.2.0/gems/prism-1.9.0/ext/prism
    C:/ProgramFiles64Folder/PuppetLabs/DevelopmentKit/private/ruby/3.2.10/bin/ruby.exe
    -I
    C:/ProgramFiles64Folder/PuppetLabs/DevelopmentKit/private/ruby/3.2.10/lib/ruby/site_ruby/3.2.0
    extconf.rb
    checking for prism.h in
    C:/ProgramFiles64Folder/PuppetLabs/DevelopmentKit/private/ruby/3.2.10/lib/ruby/gems/3.2.0/gems/prism-1.9.0/include...

[1] https://github.com/rubocop/rubocop-ast/pull/373/changes#diff-b033ecce58abc19c812c3cb986447affccedc866655547668ede144dc4bbb83d

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
