### PR TITLE
(maint) Correct CFPropertlyList platforms, replace deprecated Windows platforms

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -609,10 +609,7 @@ Gemfile:
       - gem: 'CFPropertyList'
         version:
         - '< 3.0.7'
-        platforms:
-          - mswin
-          - mingw
-          - x64_mingw
+        condition: "RUBY_PLATFORM.include?('darwin')"
       - gem: 'serverspec'
         version: '~> 2.41'
 spec/default_facts.yml:

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -569,21 +569,15 @@ Gemfile:
       - gem: 'rubocop-ast'
         version: '< 1.43.0'
         platforms:
-          - mswin
-          - mingw
-          - x64_mingw
+          - windows
       - gem: 'rb-readline'
         version: '= 0.5.5'
         platforms:
-          - mswin
-          - mingw
-          - x64_mingw
+          - windows
       - gem: 'bigdecimal'
         version: '< 3.2.2'
         platforms:
-          - mswin
-          - mingw
-          - x64_mingw
+          - windows
     ':development, :release_prep':
       - gem: 'puppet-strings'
         version: '~> 4.0'
@@ -597,14 +591,14 @@ Gemfile:
         - '~> 2.0'
         platforms:
           - ruby
-          - x64_mingw
+          - windows
         condition: "!ENV['PUPPET_FORGE_TOKEN'].to_s.empty?"
       - gem: 'puppet_litmus'
         version:
         - '~> 1.0'
         platforms:
           - ruby
-          - x64_mingw
+          - windows
         condition: "ENV['PUPPET_FORGE_TOKEN'].to_s.empty?"
       - gem: 'CFPropertyList'
         version:


### PR DESCRIPTION
## Summary
This PR does two things:

- Limits the CFPropertyList gem to macOS instead of Windows, as it is a macOS-specific gem.
- Replaces deprecated Windows platforms (`mswin`, `mingw`) with `windows` (see: https://github.com/ruby/rubygems/commit/0ca6dc39845a9ae3d7ea6bc0740df5db846dcfa5).

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
