### PR TITLE
(CAT-2569) Remove rubocop-ast gem dependency pin

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -566,10 +566,6 @@ Gemfile:
         version: '~> 2.27.0'
       - gem: 'rubocop-capybara'
         version: '~> 2.22.0'
-      - gem: 'rubocop-ast'
-        version: '< 1.43.0'
-        platforms:
-          - windows
       - gem: 'rb-readline'
         version: '= 0.5.5'
         platforms:


### PR DESCRIPTION
## Summary
Blocked by: https://github.com/puppetlabs/pdk-vanagon-private/pull/18

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
