### PR TITLE
Remove '/..yml' from ignored files list

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -58,7 +58,6 @@ common:
     - '/Rakefile'
     - '/rakelib/'
     - '/.rspec'
-    - '/..yml'
     - '/.yardopts'
     - '/spec/'
     - '/.vscode/'


### PR DESCRIPTION
Removes the bogus line "/..yml" from config_defaults.yml introduced in [428f39ccd](https://github.com/puppetlabs/pdk-templates/commit/428f39ccd) on https://github.com/puppetlabs/pdk-templates/pull/510

Found this during a code review of our module after running pdk convert, traced it back to this change. 

Originally this line used to say "/.rubocop.yml" before it was changed to "/..yml" a few years ago