### PR TITLE
(CAT-2581) Add faraday and Ruby 4 json pin to template Gemfile

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -520,6 +520,9 @@ Gemfile:
       - gem: json
         version: '= 2.6.3'
         condition: "Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
+      - gem: json
+        version: '= 2.18.0'
+        condition: "Gem::Requirement.create(['>= 4.0.0', '< 5.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
         # Forces ruby to use builtin racc vs trying to compile native extensions.
       - gem: racc
         version: '~> 1.4.0'
@@ -596,6 +599,9 @@ Gemfile:
           - ruby
           - windows
         condition: "ENV['PUPPET_FORGE_TOKEN'].to_s.empty?"
+      - gem: 'faraday'
+        version:
+        - '~> 2.5'
       - gem: 'CFPropertyList'
         version:
         - '< 3.0.7'


### PR DESCRIPTION
## Summary

Add two entries to config_defaults.yml so that modules rendered from pdk-templates resolve cleanly under Ruby 4 + Bundler 4:

* Unconditional `faraday ~> 2.5` in the :system_tests group. Forces Bundler away from Faraday 1.x in the puppet_litmus -> bolt -> orchestrator_client chain. Faraday 1.x lists every adapter gem
  - including faraday-patron - as a hard runtime dependency, which drags in patron 0.13.4 and its libcurl-dev native build requirement. Faraday 2.x splits adapters into optional gems, so pinning to 2.5+ avoids the patron drag-in entirely. orchestrator_client 0.7.2 accepts faraday >= 1.4, < 3.0, so 2.5+ satisfies its constraint. PDK itself already runs on faraday 2.12, so the pin is safe on every Ruby version.

* Ruby-4-conditional `json = 2.18.0` in the :development group. Mirrors the existing 3.1/3.2 json pin pattern; pins json to the version that ships in the Ruby 4.0 stdlib so Bundler doesn't pick a newer rubygems.org build that requires native compilation.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
