### PR TITLE
(CAT-2661) Default puppet_litmus to ~> 2.5 unconditionally

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -587,18 +587,7 @@ Gemfile:
     ':system_tests':
       - gem: 'puppet_litmus'
         version:
-        - '~> 2.0'
-        platforms:
-          - ruby
-          - windows
-        condition: "!ENV['PUPPET_FORGE_TOKEN'].to_s.empty?"
-      - gem: 'puppet_litmus'
-        version:
-        - '~> 1.0'
-        platforms:
-          - ruby
-          - windows
-        condition: "ENV['PUPPET_FORGE_TOKEN'].to_s.empty?"
+        - '~> 2.5'
       - gem: 'faraday'
         version:
         - '~> 2.5'


### PR DESCRIPTION
Remove the PUPPET_FORGE_TOKEN-conditional puppet_litmus entries (~> 2.0 and ~> 1.0) in favour of a single ~> 2.5 dependency.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
