### PR TITLE
(CAT-2662) Update CI templates for safe fork-PR CI

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -5,14 +5,31 @@ on:
   pull_request:
     branches:
       - "main"
+  pull_request_target:
+    types: [labeled, reopened]
+    branches:
+      - "main"
   workflow_dispatch:
-    
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Spec:
+    if: github.event_name != 'pull_request_target'
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
-    secrets: "inherit"
 
   Acceptance:
-    needs: Spec
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.fork == false) ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.head.repo.fork == true &&
+       contains(github.event.pull_request.labels.*.name, 'allowed-for-ci'))
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"

--- a/moduleroot/.github/workflows/fork_ci_label_guard.yml.erb
+++ b/moduleroot/.github/workflows/fork_ci_label_guard.yml.erb
@@ -1,0 +1,13 @@
+<% common = config_for('common') -%>
+name: "Fork CI Label Guard"
+
+on:
+  pull_request_target:
+    types: [synchronize, closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  strip:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/fork_ci_label_guard.yml@main"


### PR DESCRIPTION
## Summary

- Replaces `ci.yml.erb` with the two-track caller pattern (`pull_request` for Spec, `pull_request_target` + label for fork-PR Acceptance).
- Adds new `fork_ci_label_guard.yml.erb` that strips the `allowed-for-ci` label on `synchronize` / `closed` to force a fresh CODEOWNER review before any subsequent acceptance run.

## Rendered behaviour

| Trigger | Spec | Acceptance |
|---|---|---|
| Same-repo PR | runs (no secrets) | runs (with secrets), no env approval |
| Fork PR (unlabelled) | runs (no secrets) | skipped |
| Fork PR (labelled `allowed-for-ci`) | runs (no secrets) | runs (with secrets) after env approval |
| `workflow_dispatch` | runs | runs |

Non-updated modules (`@some-tag` pins, opted-out via `.sync.yml`) are unaffected until they next run `pdk update`.

## Blocks on

[`CAT-2632`](https://github.com/puppetlabs/cat-github-actions/tree/CAT-2632-enable_safe_fork_pr_ci) in `puppetlabs/cat-github-actions`. The reusable workflows referenced via `@main` don't exist on that repo's `main` until that PR merges. Marking this draft until it does.

## Per-module rollout (out of scope here)

Each module owner has to configure the GitHub-side prerequisites before fork PRs use the new path: the `allowed-for-ci` label, the `puppetcore-fork` environment with required reviewers, branch protection on workflow files, and a repo-role audit. The checklist lives in `docs/how-to/fork-pr-ci.md` in the linked `cat-github-actions` branch.

## Test plan

- [x] `pdk update` on a sample module renders both templates without errors.
- [x] Rendered `ci.yml` matches the pattern verified end-to-end on the `puppetlabs/motd` pilot under CAT-2632.
- [x] `actionlint` clean on the rendered output (verified locally).
- [x] Once CAT-2632 merges, mark this Ready for Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)