### PR TITLE
(CAT-2600) Make bolt opt-in in generated module Gemfile

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -132,7 +132,7 @@ puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
 facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
 hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
-gems['bolt'] = location_for(bolt_version, nil, { source: gemsource_puppetcore })
+gems['bolt'] = location_for(bolt_version, nil, { source: gemsource_puppetcore }) if bolt_version
 gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
 gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
 gems['hiera'] = location_for(hiera_version, nil, {}) if hiera_version


### PR DESCRIPTION
## Problem

[CAT-2600](https://perforce.atlassian.net/browse/CAT-2600): `pdk validate` fails with `version solving has failed` on a repo validating against Puppet 8.10.0.

[CAT-2357](https://github.com/puppetlabs/pdk-templates/commit/6aaf6d815283b6baa2ca54ba274dca83d8b33e91) added an **unconditional, unpinned** `bolt` to the generated module `Gemfile` (`moduleroot/Gemfile.erb`). The bolt line is sourced from puppetcore, so Bundler resolves it to **bolt 5.x**, whose gemspec hard-requires `puppet >= 8.11` **and** `facter ~> 4.11` — both puppetcore-only. PDK pins puppet to the version it ships (8.10.0), so resolution dies before any validator runs:

```
Because every version of bolt depends on puppet ~> 8.11
 and Gemfile depends on bolt >= 0,
 puppet ~> 8.11 is required.
So, because Gemfile depends on puppet = 8.10.0,
 version solving has failed.
```

Every module inherited bolt's Puppet floor — even modules that never touch bolt.

## Fix

Guard the `bolt` line with `if bolt_version`, exactly mirroring the existing `hiera` line, so `bolt` only enters the Gemfile when the user explicitly opts in via `BOLT_GEM_VERSION`:

```diff
-gems['bolt'] = location_for(bolt_version, nil, { source: gemsource_puppetcore })
+gems['bolt'] = location_for(bolt_version, nil, { source: gemsource_puppetcore }) if bolt_version
```

This is safe: bolt specs are already gated behind `ENV['GEM_BOLT']` (`spec/spec_helper.rb.erb`), so a normal `pdk validate` run never needs bolt present. Users who do want bolt set `BOLT_GEM_VERSION` and take responsibility for a compatible puppet/bolt pair.

## Verification

Using `bundle lock --print` (non-destructive) with the bolt 5.x constraint stood up via a local `bolt-private` path gem:

- **Before** — `gem 'puppet', '8.10.0'` + unconditional `gem 'bolt'` → `version solving has failed`.
- **After (default run, `BOLT_GEM_VERSION` unset)** — Gemfile carries no `bolt` line → resolves to `puppet (8.10.0)`; validation proceeds.
- **Guard logic** — `BOLT_GEM_VERSION` unset → bolt line skipped; set → bolt line emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## How it works (before vs after)

`bolt` is in the resolution either way, because the default Gemfile pulls `puppet_litmus (~> 2.5)` → `bolt (>= 4.0, < 6.0)`. The fix only changes *which* `bolt` Bundler may pick.

**Before — the template's direct, unpinned puppetcore `bolt` forces 5.x, which needs `puppet >= 8.11`:**

```mermaid
flowchart TD
    P["puppet pinned = 8.10.0"]
    D["template: gem 'bolt' UNPINNED, source: puppetcore"] --> B5["puppetcore newest bolt = 5.x → needs puppet >= 8.11"]
    P --> R{"one puppet for all?"}
    B5 --> R
    R -->|"8.10.0 is not >= 8.11"| F["version solving has failed"]
    style F fill:#f8d7da,stroke:#dc3545
```

**After — bolt is only constrained by `puppet_litmus` (public), so Bundler picks 4.0.0, happy with 8.10.0:**

```mermaid
flowchart TD
    P["puppet pinned = 8.10.0"]
    L["puppet_litmus → bolt >= 4.0, < 6.0 (public)"] --> B4["Bundler picks bolt 4.0.0 (public)"]
    P --> R{"one puppet for all?"}
    B4 --> R
    R --> OK["resolves: puppet 8.10.0 + bolt 4.0.0"]
    style OK fill:#d1e7dd,stroke:#198754
```

Opt-in is preserved: set `BOLT_GEM_VERSION` to pull `bolt` from puppetcore again (requires an all-puppetcore stack, puppet >= 8.11).
