### PR TITLE
(MODULES-11832) Add synced PR template with outcome-based review policy

### DIFF
--- a/moduleroot/.github/PULL_REQUEST_TEMPLATE.md.erb
+++ b/moduleroot/.github/PULL_REQUEST_TEMPLATE.md.erb
@@ -20,12 +20,8 @@ flag any unrelated cleanup as a separate ticket/PR.
 
 - [ ] Linked the driving `MODULES-*` ticket above using the structured spec template.
 - [ ] Coverage gate is green (or the baseline is preserved -- coverage was not reduced).
-- [ ] Platform matrix result link included below (CI run or nightly Litmus result).
+- [ ] Platform matrix is green -- the PR's CI checks below cover it, or link a recent nightly Litmus run if the supported-OS acceptance tests do not run on this PR.
 - [ ] `Co-Authored-By: Claude` trailer is present on the commits if this PR was AI-assisted.
-
-## Platform matrix result
-
-<!-- Paste the link to the CI / nightly Litmus run that proves the supported OS matrix is green. -->
 
 ## Review policy (outcome-based)
 

--- a/moduleroot/.github/PULL_REQUEST_TEMPLATE.md.erb
+++ b/moduleroot/.github/PULL_REQUEST_TEMPLATE.md.erb
@@ -1,0 +1,50 @@
+<!--
+  This pull request template is synced from puppetlabs/pdk-templates
+  (moduleroot/.github/PULL_REQUEST_TEMPLATE.md.erb). Do not edit it directly in a
+  module repo -- changes are overwritten on the next `pdk update`. To customise it
+  for a single module, opt out with `.github/PULL_REQUEST_TEMPLATE.md: unmanaged: true`
+  in the module's `.sync.yml` and maintain a hand-written copy.
+-->
+
+## Summary
+
+Describe what this change does and why. Keep the change scoped to the linked ticket;
+flag any unrelated cleanup as a separate ticket/PR.
+
+## Related ticket
+
+<!-- Link the driving ticket using the structured spec template. -->
+- Ticket: MODULES-XXXX
+
+## Required checklist
+
+- [ ] Linked the driving `MODULES-*` ticket above using the structured spec template.
+- [ ] Coverage gate is green (or the baseline is preserved -- coverage was not reduced).
+- [ ] Platform matrix result link included below (CI run or nightly Litmus result).
+- [ ] `Co-Authored-By: Claude` trailer is present on the commits if this PR was AI-assisted.
+
+## Platform matrix result
+
+<!-- Paste the link to the CI / nightly Litmus run that proves the supported OS matrix is green. -->
+
+## Review policy (outcome-based)
+
+PRs are judged on outcomes, not line counts. Pick the lane that matches this change so
+reviewers know what coverage to expect. See `CLAUDE.md` for the full policy.
+
+- **Auto-merge** -- green CI required, no human review needed:
+  dependabot bumps, modulesync / `pdk update` resync, doc-only changes, `REFERENCE.md` regeneration.
+- **Single reviewer** -- green CI plus coverage preserved required:
+  bug fixes, supported-platform additions, simple feature work.
+- **Full review (2 or more reviewers)** -- green CI plus coverage plus senior sign-off:
+  provider / type-API changes, security fixes, breaking changes.
+
+This PR is (check one):
+
+- [ ] Auto-merge
+- [ ] Single reviewer
+- [ ] Full review (2+)
+
+## Additional context
+
+<!-- Root cause, reproduction steps, and the reasoning behind the implementation, if applicable. -->

--- a/moduleroot/.github/PULL_REQUEST_TEMPLATE.md.erb
+++ b/moduleroot/.github/PULL_REQUEST_TEMPLATE.md.erb
@@ -1,7 +1,7 @@
 <!--
   This pull request template is synced from puppetlabs/pdk-templates
   (moduleroot/.github/PULL_REQUEST_TEMPLATE.md.erb). Do not edit it directly in a
-  module repo -- changes are overwritten on the next `pdk update`. To customise it
+  module repo -- changes are overwritten on the next `pdk update`. To customize it
   for a single module, opt out with `.github/PULL_REQUEST_TEMPLATE.md: unmanaged: true`
   in the module's `.sync.yml` and maintain a hand-written copy.
 -->
@@ -11,14 +11,15 @@
 Describe what this change does and why. Keep the change scoped to the linked ticket;
 flag any unrelated cleanup as a separate ticket/PR.
 
-## Related ticket
+## Related ticket / issue
 
-<!-- Link the driving ticket using the structured spec template. -->
-- Ticket: MODULES-XXXX
+<!-- Link the driving Jira ticket (MODULES-*) using the structured spec template, a
+     community/customer GitHub issue, or leave blank if there is nothing to link. -->
+- Ticket / issue: MODULES-XXXX
 
 ## Required checklist
 
-- [ ] Linked the driving `MODULES-*` ticket above using the structured spec template.
+- [ ] Linked the driving ticket or issue above where one exists (a `MODULES-*` ticket via the structured spec template, or a GitHub issue).
 - [ ] Coverage gate is green (or the baseline is preserved -- coverage was not reduced).
 - [ ] Platform matrix is green -- the PR's CI checks below cover it, or link a recent nightly Litmus run if the supported-OS acceptance tests do not run on this PR.
 - [ ] `Co-Authored-By: Claude` trailer is present on the commits if this PR was AI-assisted.
@@ -29,7 +30,8 @@ PRs are judged on outcomes, not line counts. Pick the lane that matches this cha
 reviewers know what coverage to expect. See `CLAUDE.md` for the full policy.
 
 - **Auto-merge** -- green CI required, no human review needed:
-  dependabot bumps, modulesync / `pdk update` resync, doc-only changes, `REFERENCE.md` regeneration.
+  dependabot bumps, modulesync / `pdk update` resync, `REFERENCE.md` regeneration, trivial doc fixes (typos, link fixes).
+  Substantial doc changes -- e.g. a significant `README.md` rewrite -- still warrant a human review.
 - **Single reviewer** -- green CI plus coverage preserved required:
   bug fixes, supported-platform additions, simple feature work.
 - **Full review (2 or more reviewers)** -- green CI plus coverage plus senior sign-off:


### PR DESCRIPTION
## Summary

Adds `moduleroot/.github/PULL_REQUEST_TEMPLATE.md.erb` so every CAT-supported module receives a synced PR template on the next `pdk update`. Today modules only get the repo-level template that lives in their own `.github/`; this gives them a consistent, policy-bearing template managed centrally from pdk-templates.

The template enforces the S2 outcome-based review policy:

- **Required checklist** — structured-ticket linkage (`MODULES-*`), coverage gate green / baseline preserved, platform matrix result link, and a `Co-Authored-By: Claude` trailer when the PR is AI-assisted.
- **Outcome-based review lanes** — auto-merge / single reviewer / full review (2+), with the criteria for each lane. Wording is kept consistent with the policy documented in `moduleroot/CLAUDE.md` (added in #642).

## Notes

- **Managed, not `unmanaged`** — so the policy stays consistent across all modules. A module can still opt out via `.github/PULL_REQUEST_TEMPLATE.md: unmanaged: true` in its `.sync.yml`.
- Pure ASCII, matching pdk-templates' editing expectations for synced files.

## Testing

Verified with `pdk convert --noop` against `puppetlabs-lvm`: the template renders to `.github/PULL_REQUEST_TEMPLATE.md` and cleanly replaces the module's existing repo-level template. No ERB leakage; header sync comment renders as a markdown comment.

## Related

- Ticket: [MODULES-11832](https://perforce.atlassian.net/browse/MODULES-11832)
- Epic: [MODULES-11828](https://perforce.atlassian.net/browse/MODULES-11828) (S2 Maturity Enablement)
- Sibling artifact: #642 (synced `moduleroot/CLAUDE.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
