### PR TITLE
(CAT-2581) Open puppet-blacksmith constraint to `>= 7.0, < 10.0`

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -583,7 +583,9 @@ Gemfile:
       - gem: 'puppetlabs_spec_helper'
         version: '~> 8.0'
       - gem: 'puppet-blacksmith'
-        version: '~> 7.0'
+        version:
+        - '>= 7.0'
+        - '< 10.0'
     ':system_tests':
       - gem: 'puppet_litmus'
         version:


### PR DESCRIPTION
## Summary

Open the `puppet-blacksmith` constraint in `config_defaults.yml`'s `:development, :release_prep` group from `'~> 7.0'` to a list-form `['>= 7.0', '< 10.0']` so newly-rendered module Gemfiles can resolve cleanly on Ruby 4 + bolt 5.1.1.

## Why this PR exists

This is a companion to [puppetlabs/pdk-private#48](https://github.com/puppetlabs/pdk-private/pull/48) (Jira [CAT-2581](https://perforce.atlassian.net/browse/CAT-2581) — "Update pdk-private to test against Ruby 4"). After bolt 5.1.1 landed on puppetcore with a relaxed `minitar ~> 1.0` constraint, PDK's Ruby 4 acceptance lanes hit a different deadlock through the `puppet-blacksmith` transitive chain:

```
bolt 5.1.1                       → minitar ~> 1.0
puppet-modulebuilder ~> 1.0      → minitar ~> 0.9       ⛔ conflicts
puppet-blacksmith ~> 7.0         → puppet-modulebuilder ~> 1.0
Gemfile (current pdk-templates)  → puppet-blacksmith ~> 7.0

Result: Bundler: no version of minitar satisfies both
```

CI signal on PR #48 with the old constraint:

```
Could not find compatible versions

bolt >= 5.1.1 depends on minitar ~> 1.0
...
puppet-modulebuilder >= 0.3.0, < 2.1.0 depends on minitar ~> 0.9
...
Gemfile depends on puppet-blacksmith ~> 7.0
version solving has failed.
```

## What this PR changes

```diff
       - gem: 'puppet-blacksmith'
-        version: '~> 7.0'
+        version:
+        - '>= 7.0'
+        - '< 10.0'
```

The list-form constraint matches the pattern used by other multi-constraint gems in the same file (e.g. `CFPropertyList`, `puppet_litmus`).

## Effect

- **New module renders** pick `puppet-blacksmith 9.x` (currently latest in-range) → `puppet-modulebuilder ~> 2.0, >= 2.0.2` → `puppet-modulebuilder 2.1.0` → `minitar >= 0.9, < 2`. With minitar 1.x reachable, the rest of the Ruby 4 chain (bolt 5.1.1 + puppet_forge 6.2.0+ + faraday-follow_redirects 0.5.0+) resolves cleanly.
- **Existing modules** with a `Gemfile.lock` continue to use whatever blacksmith version they already have locked — no forced bump, no migration noise.
- **Floor** stays at 7.0 — no regression for any consumer that explicitly asked for an old blacksmith.
- **Ceiling** at `< 10.0` keeps future major versions out of scope until reviewed (mirrors how the original `~> 7.0` constraint was a deliberate review gate, just at a more useful boundary).

## Verification

`pdk new module testmod --template-url=file://<this-clone> --template-ref=CAT-2581` produces a Gemfile whose blacksmith line reads:

```ruby
gem "puppet-blacksmith", '>= 7.0', '< 10.0', require: false
```

i.e. the template change correctly translates into the rendered constraint.

End-to-end Ruby 4 acceptance unblock will be verified once this lands and PR #48 CI re-runs.

## Related

- pdk-private PR: https://github.com/puppetlabs/pdk-private/pull/48
- Previous companion (merged): puppetlabs/pdk-templates#638 — Ruby-4-conditional json pin + unconditional faraday `~> 2.5` pin
- Previous companion (merged): puppetlabs/cat-github-actions#177 — `PUPPET_FORGE_TOKEN` propagation in `gem_acceptance.yml`
- bolt 5.1.1 release on puppetcore — the upstream gemspec relaxation that this PR pairs with
- Jira: [CAT-2581](https://perforce.atlassian.net/browse/CAT-2581)