### PR TITLE
(CAT-2637) Enable Security/Open and Security/IoMethods cops

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,17 @@ In this example the automated release prep workflow is triggered every Saturday 
 |cleanup\_cops    |Defines a set of cleanup cops to then be included within a rubocop profile. Cops are defined by their full name, and further configuration can be done by specifying secondary keys. By default we specify a large amount of cleanup cops using their default configuration.|
 |profiles         |Defines the profiles that can be enabled and used within rubocop through the `selected_profile` option. By default we have set up three profiles: cleanups\_only, strict, hardcore and off.|
 
+#### Puppet 9 subprocess-creation detection
+
+The `strict` profile enables two security cops that flag the pipe-based subprocess creation removed in Ruby 4.0 (which ships with Puppet 9). See [Ruby #19630](https://bugs.ruby-lang.org/issues/19630).
+
+| Cop | Flags | Recommended replacement |
+| :-- | :---- | :---------------------- |
+| `Security/Open` | `open(...)` / `URI.open(...)` with a pipe argument (`open("\| cmd")`) or a dynamic argument (`open(var)`). Literal file paths such as `open("foo.txt")` are not flagged. | `File.open`, `IO.popen`, or `URI.parse(...).open` |
+| `Security/IoMethods` | `IO.read` / `IO.write` / `IO.binread` / `IO.binwrite` / `IO.foreach` / `IO.readlines` used for file access (e.g. `IO.read("foo.txt")`). | `File.read`, `File.write`, etc. (autocorrectable) |
+
+Known gaps (not statically detectable, so not flagged): the explicit-receiver `Kernel.open(...)` form, and the deliberate `IO.read("| cmd")` pipe-subprocess form (intentionally allowed by `Security/IoMethods`). Both cops are overridable per module through `.sync.yml`.
+
 ### Gemfile
 
 >A Gemfile is a file we create which is used for describing gem dependencies for Ruby programs. All modules should have an associated Gemfile for installing the relevant gems. As development and testing is somewhat consistant between modules we have used the template to define a set of gems relevant to these processes.

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -452,7 +452,9 @@ Rakefile:
         RSpec/SubjectStub:
         RSpec/VerifiedDoubles:
         Security/Eval:
+        Security/IoMethods:
         Security/MarshalLoad:
+        Security/Open:
         Naming/AsciiIdentifiers:
         Style/BeginBlock:
         Style/CaseEquality:


### PR DESCRIPTION
## Summary

Enables two RuboCop security cops in the `strict` profile (the default `selected_profile`) to detect the pipe-based subprocess creation removed in Ruby 4.0, which ships with Puppet 9 — see [Ruby #19630](https://bugs.ruby-lang.org/issues/19630). Parent: CAT-2630 (PDK | Puppet 9 Compatibility Testing).

- **`Security/Open`** — flags `open()` / `URI.open()` called with a pipe argument (`open("| cmd")`) or a dynamic argument (`open(var)`). Literal file paths such as `open("foo.txt")` are not flagged. Recommended replacements: `File.open`, `IO.popen`, `URI.parse(...).open`. **PDK was previously explicitly disabling this cop** (it is enabled-by-default in RuboCop but was excluded from the profile lists); it is now active.
- **`Security/IoMethods`** — flags `IO.read` / `write` / `binread` / `binwrite` / `foreach` / `readlines` used for file access and steers them to the `File.*` equivalents (autocorrectable). The deliberate `IO.read("| cmd")` pipe form is intentionally left valid.

`hardcore` already covered both via `all`. Both cops remain overridable per module through `.sync.yml`.

## Additional Context

The ticket asked us to investigate before implementing. Empirically verifying the cops (reading the cop sources and running them at rubocop 1.50.2 and 1.73.2, and checking 1.87.0) corrected two claims from the original investigation:

- `Security/Open` only catches the **literal** pipe form (`open("| cmd")`) from rubocop ~1.71 onward — at 1.50.x the matcher is `$!str` (dynamic args only). We are fine because the `Gemfile` pins `rubocop ~> 1.73.0`, where the matcher is `$_` and both literal-pipe and dynamic forms are flagged. It covers bare `open` / `URI.open` only — not `IO.open` or explicit-receiver `Kernel.open(...)`.
- `Security/IoMethods` does the **inverse** of what the ticket title's "IO.open pipe" wording implies (unchanged through 1.87.0): it flags file-access `IO.*` and *skips* the `IO.read("| cmd")` pipe form. This was accepted on the ticket — intentional subprocess use stays valid, and the `IO.* -> File.*` nudge is a reasonable autocorrectable style enforcement.

**Verification (full ERB render of `moduleroot/.rubocop.yml.erb` + run at rubocop 1.73.2):**

| Code | Result |
| :--- | :----- |
| `open("\| ls")` | flagged (literal pipe) |
| `open(var)` | flagged (dynamic) |
| `open("foo.txt")` | clean (no false positive) |
| `IO.read("file.txt")` | flagged -> `File.read` |
| `IO.read("\| cmd")` | clean (intentional pipe) |
| `IO.popen("ls")` | clean (replacement API) |

Render confirms `Security/IoMethods: { Enabled: true }`; `Security/Open` is active via RuboCop's built-in default (same pattern as the existing `Security/Eval`). `bundle exec rubocop` on this repo is clean.

Known residual gap (documented in the README, not statically detectable without a bespoke cop — scoped out): `IO.read("| cmd")` subprocess use and the explicit-receiver `Kernel.open(...)` form.

## Related Issues (if any)

- [CAT-2637](https://perforce.atlassian.net/browse/CAT-2637) — PDK | Add Rubocop cop for Kernel.open / IO.open subprocess creation
- Parent: [CAT-2630](https://perforce.atlassian.net/browse/CAT-2630) — PDK | Puppet 9 Compatibility Testing

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
