### PR TITLE
(CAT-2635) Add rubocop-hash_inspect to PDK rubocop gem group and plugins

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -563,6 +563,8 @@ Gemfile:
         version: '~> 1.73.0'
       - gem: 'rubocop-performance'
         version: '~> 1.24.0'
+      - gem: 'rubocop-hash_inspect'
+        version: '~> 0.2'
       - gem: 'rubocop-rspec'
         version: '~> 3.5.0'
       - gem: 'rubocop-rspec_rails'

--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -3,6 +3,7 @@
 defaults = {
   'plugins' => [
     'rubocop-performance',
+    'rubocop-hash_inspect',
     'rubocop-rspec',
     'rubocop-rspec_rails',
     'rubocop-factory_bot',


### PR DESCRIPTION
## Summary

Ruby 3.4 (December 2024, [Bug #20433](https://bugs.ruby-lang.org/issues/20433)) changed the output of `Hash#inspect` from the legacy rocket syntax to colon syntax:

| Ruby version | `{a: 1, "b" => 2}.inspect` output |
|---|---|
| Ruby <= 3.3 (Puppet 8) | `{:a=>1, "b"=>2}` |
| Ruby >= 3.4 (Puppet 9 / Ruby 4) | `{a: 1, "b" => 2}` |

Test assertions that hardcode the old format — for example `eq("{:a=>1}")` or `match(/\{:name=>"foo"\}/)` — silently break on Puppet 9. The [`rubocop-hash_inspect`](https://github.com/puppetlabs/rubocop-hash_inspect) gem provides a single conservative cop (`HashInspect/LegacyHashInspectFormat`) that flags those literals statically during `pdk validate`, so module authors can fix them before upgrading.

This PR adds `rubocop-hash_inspect ~> 0.2` to the `:development` gem group in `config_defaults.yml` (alongside `rubocop-performance` and `rubocop-rspec`) and adds `'rubocop-hash_inspect'` to the `defaults['plugins']` array in `moduleroot/.rubocop.yml.erb`, so the cop runs automatically on every `pdk validate` after a `pdk update`.

## Additional Context

**Before (Ruby 3.4 / Puppet 9 breaks silently):**
```ruby
expect(result.inspect).to eq("{:a=>1}")
expect(msg).to match(/\{:name=>"foo"\}/)
```

**After — the cop flags these on `pdk validate`:**
```
Offense: Legacy `Hash#inspect` format (`{:sym=>...}`). Ruby 3.4+ renders hashes as
`{sym: ...}`, so this hardcoded value breaks on Ruby 3.4 / Puppet 9. Update it to
the new format.
```

**Correct form:**
```ruby
expect(result.inspect).to eq("{a: 1}")
expect(msg).to match(/\{name: "foo"\}/)
# Or better — use a matcher that doesn't depend on inspect output:
expect(result).to eq({ a: 1 })
```

**Version constraint:** `~> 0.2` targets the published `0.2.0` release (pessimistic minor lock — compatible with any `0.2.x` patch but will not automatically pull in a future `0.3.0`/`1.0.0` that may change detection semantics).

**On by default:** The cop ships enabled at `convention` severity, matching `rubocop-performance`. It is non-blocking (PDK does not fail `validate` on convention offenses) and produces no false positives against the `puppetlabs-stdlib` and `puppetlabs-concat` baseline corpora.

**A note on the ERB template comment:** `moduleroot/.rubocop.yml.erb` carries the comment _"note that these hashes need to use rockets, not colons, because rubocop config requires strings as keys"_. That refers to the ERB hash-key syntax used to render the template (writing `'plugins' => [...]` rather than `plugins: [...]`), and is unrelated to the string *values* the cop flags. Config files are outside the cop's detection scope — only string and regexp literals in module source code are checked.

## Related Issues (if any)

- Jira: [CAT-2635](https://perforce.atlassian.net/browse/CAT-2635) (parent epic CAT-2630 — PDK | Puppet 9 Compatibility Testing)
- Gem: [rubocop-hash_inspect on RubyGems](https://rubygems.org/gems/rubocop-hash_inspect) (`0.2.0` live)
- Ruby Bug: [#20433](https://bugs.ruby-lang.org/issues/20433)

## Checklist
- [x] 🟢 Spec tests.
- [x] Manually verified.
