### PR TITLE
(CAT-2682) Add customizable acceptance_flags for CI/nightly workflow Acceptance jobs

### DIFF
--- a/.ci/fixtures/new_provider_sync.yml
+++ b/.ci/fixtures/new_provider_sync.yml
@@ -9,3 +9,17 @@ spec/spec_helper.rb:
   default_configs:
     Performance/CaseWhenSplat:
       Enabled: false
+.github/workflows/ci.yml:
+  unmanaged: false
+  acceptance_flags:
+    - '-----nightly'
+    - '--platform-exclude centos-7'
+    - '--platform-exclude oraclelinux-7'
+    - '--message "hello"'
+.github/workflows/nightly.yml:
+  unmanaged: false
+  acceptance_flags:
+    - '-----nightly'
+    - '--platform-exclude centos-7'
+    - '--platform-exclude oraclelinux-7'
+    - '--message "hello"'

--- a/.ci/test_script.sh
+++ b/.ci/test_script.sh
@@ -12,10 +12,14 @@ git checkout -b ci_commit
 pdk new module new_module --template-url="file://$TEMPLATE_PR_DIR" --template-ref=ci_commit --skip-interview
 pushd new_module
 grep template < metadata.json
+[ ! -f .github/workflows/ci.yml ] # ci.yml is unmanaged: true by default, so PDK skips rendering it entirely -- byte-identical to pre-acceptance_flags behavior (TEST-02a)
+[ ! -f .github/workflows/nightly.yml ] # nightly.yml is unmanaged: true by default, so PDK skips rendering it entirely -- byte-identical to pre-acceptance_flags behavior (TEST-02a, D-13)
 cp "$TEMPLATE_PR_DIR/.ci/fixtures/new_provider_sync.yml" ./.sync.yml
 grep -A 1 "Performance/CaseWhenSplat" ./.rubocop.yml | grep -q "true" # Ensure that the template is applied
 pdk update --force
 grep -A 1 "Performance/CaseWhenSplat" ./.rubocop.yml | grep -q "false" # Ensure that the update command changes the template
+grep -qF 'flags: "--platform-exclude centos-7 --platform-exclude oraclelinux-7 --message \"hello\""' .github/workflows/ci.yml # Ensure acceptance_flags override + knockout + repeated-flag-name (CR-01 regression) + adversarial quote render on ci.yml (TEST-01, TEST-02b)
+grep -qF 'flags: "--platform-exclude centos-7 --platform-exclude oraclelinux-7 --message \"hello\""' .github/workflows/nightly.yml # Ensure acceptance_flags override + knockout + repeated-flag-name (CR-01 regression) + adversarial quote render on nightly.yml independently (TEST-01, TEST-02b, D-13)
 pdk new class new_module
 pdk new defined_type test_type
 pdk new fact test_fact || true # not available in pdk 1.18 yet

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 # Rubocop profile builder temporary files
 /rubocop/.rubocop.yml
 /rubocop/.rubocop_todo.yml
+
+# GSD planning docs (local-only, not committed)
+/.planning/

--- a/README.md
+++ b/README.md
@@ -200,6 +200,48 @@ release_schedule:
 
 In this example the automated release prep workflow is triggered every Saturday at 3 am.
 
+### .github/workflows/ci.yml and .github/workflows/nightly.yml
+
+> `ci.yml` and `nightly.yml` are `unmanaged: true` by default (see [Unmanaged and delete keys](#unmanaged-and-delete-keys)), so `acceptance_flags` has no effect on an existing module until that module's own `.sync.yml` sets `unmanaged: false` for the file(s) to be managed:
+
+```yaml
+.github/workflows/ci.yml:
+  unmanaged: false
+```
+
+The `acceptance_flags` key controls the flags passed to the Acceptance job via a `with: flags: "..."` entry on the `module_acceptance.yml` reusable workflow. It defaults to `acceptance_flags: ['--nightly']` under both `.github/workflows/ci.yml` and `.github/workflows/nightly.yml`, rendering as `flags: "--nightly"` when left at default.
+
+Flags can be added or removed using the same array syntax described in [Adding configuration values](#adding-configuration-values) and [Removing default configuration values](#removing-default-configuration-values) (prefix a value with `---` to remove it).
+
+> **Important:** the underlying array merge is a set union — it silently drops any array element that repeats a value already present elsewhere in the array. If you need a flag that takes a value and can appear multiple times (like `--platform-exclude`), write each occurrence as **one combined element** (`'--platform-exclude centos-7'`), not as two separate elements (`'--platform-exclude'`, `'centos-7'`). Splitting flag and value across separate elements causes every repeat of the bare flag token to collapse into a single occurrence, silently dropping the rest.
+
+For example, `puppetlabs-firewall` currently hand-maintains the flags `--nightly --platform-exclude centos-7 --platform-exclude oraclelinux-7 --platform-exclude scientific-7 --platform-exclude centos-8 --platform-exclude rocky-8` directly in its own frozen (`unmanaged: true`) workflow file rather than through `acceptance_flags`. The following shows what firewall would write in `.sync.yml` to manage this via PDK instead:
+
+```yaml
+.github/workflows/ci.yml:
+  unmanaged: false
+  acceptance_flags:
+    - '--nightly'
+    - '--platform-exclude centos-7'
+    - '--platform-exclude oraclelinux-7'
+    - '--platform-exclude scientific-7'
+    - '--platform-exclude centos-8'
+    - '--platform-exclude rocky-8'
+.github/workflows/nightly.yml:
+  unmanaged: false
+  acceptance_flags:
+    - '--nightly'
+    - '--platform-exclude centos-7'
+    - '--platform-exclude oraclelinux-7'
+    - '--platform-exclude scientific-7'
+    - '--platform-exclude centos-8'
+    - '--platform-exclude rocky-8'
+```
+
+This renders exactly `flags: "--nightly --platform-exclude centos-7 --platform-exclude oraclelinux-7 --platform-exclude scientific-7 --platform-exclude centos-8 --platform-exclude rocky-8"` on the Acceptance job of both workflows.
+
+To clear all flags entirely, knock out the default with `acceptance_flags: ['---']` — this omits the `with:` block completely (rather than rendering an empty `flags: ""`), so the Acceptance job runs with the reusable workflow's own defaults.
+
 ### .pdkignore
 
 >A .pdkignore file in your repo allows you to specify files to ignore when building a module package with `pdk build`.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ For example, `puppetlabs-firewall` currently hand-maintains the flags `--nightly
 
 This renders exactly `flags: "--nightly --platform-exclude centos-7 --platform-exclude oraclelinux-7 --platform-exclude scientific-7 --platform-exclude centos-8 --platform-exclude rocky-8"` on the Acceptance job of both workflows.
 
-To clear all flags entirely, knock out the default with `acceptance_flags: ['---']` — this omits the `with:` block completely (rather than rendering an empty `flags: ""`), so the Acceptance job runs with the reusable workflow's own defaults.
+To clear all flags entirely, knock out each default element individually using the same per-element knockout prefix shown above, e.g. `acceptance_flags: ['-----nightly']` to remove the `--nightly` default. This omits the `with:` block completely (rather than rendering an empty `flags: ""`), so the Acceptance job runs with the reusable workflow's own defaults. Note that the hash-key removal syntax (`acceptance_flags: '---'`) does **not** achieve this — it merges to an empty string, which still renders `flags: ""` rather than omitting the block.
 
 ### .pdkignore
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -617,8 +617,10 @@ spec/spec_helper.rb:
   strict_variables: true
 .github/workflows/ci.yml:
   unmanaged: true
+  acceptance_flags: ['--nightly']
 .github/workflows/nightly.yml:
   unmanaged: true
+  acceptance_flags: ['--nightly']
 .github/workflows/release.yml:
   unmanaged: true
 .github/workflows/release_prep.yml:

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -1,4 +1,5 @@
 <% common = config_for('common') -%>
+<% acceptance_flags = Array(@configs['acceptance_flags']) -%>
 name: "ci"
 
 on:
@@ -32,4 +33,8 @@ jobs:
        github.event.pull_request.head.repo.fork == true &&
        contains(github.event.pull_request.labels.*.name, 'allowed-for-ci'))
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+<% unless acceptance_flags.empty? -%>
+    with:
+      flags: <%= acceptance_flags.join(' ').to_json %>
+<% end -%>
     secrets: "inherit"

--- a/moduleroot/.github/workflows/nightly.yml.erb
+++ b/moduleroot/.github/workflows/nightly.yml.erb
@@ -1,4 +1,5 @@
 <% common = config_for('common') -%>
+<% acceptance_flags = Array(@configs['acceptance_flags']) -%>
 name: "nightly"
 
 on:
@@ -14,4 +15,8 @@ jobs:
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+<% unless acceptance_flags.empty? -%>
+    with:
+      flags: <%= acceptance_flags.join(' ').to_json %>
+<% end -%>
     secrets: "inherit"


### PR DESCRIPTION
## Summary

Adds a new `acceptance_flags` config key so consumer modules can customize the acceptance-test flags passed to the `module_acceptance.yml` reusable workflow in both `.github/workflows/ci.yml` and `.github/workflows/nightly.yml`, via `config_defaults.yml` (repo-wide default) and `.sync.yml` (per-module additions/removals) — without needing to mark the whole workflow file `unmanaged: true`.

- `config_defaults.yml`: adds a per-file `acceptance_flags` array (independent for `ci.yml`/`nightly.yml`, not shared via YAML anchor), defaulting to `['--nightly']`
- `ci.yml.erb` / `nightly.yml.erb`: each independently reads `acceptance_flags` and renders a safely-escaped `with: flags: "..."` entry on the Acceptance job when non-empty
- `README.md`: documents the key, its default, the `.sync.yml` override/knockout syntax, a worked example using `puppetlabs-firewall`'s real flags, and a prominent warning about the `unmanaged: true` precondition
- `.ci/test_script.sh` / `.ci/fixtures/new_provider_sync.yml`: permanent regression coverage for default rendering, override + knockout, and an adversarial double-quote value, across both workflow files

## Additional Context

- **Root cause:** modules such as `puppetlabs-firewall` currently hand-edit `ci.yml`/`nightly.yml` directly to add acceptance-test flags, which requires marking the whole file `unmanaged: true` and forfeiting all future template updates.
- Since `acceptance_flags` defaults to a non-empty `['--nightly']`, every freshly-rendered module now gets `flags: "--nightly"` on its Acceptance job by default — a deliberate, confirmed behavior change from today's templates.
- `ci.yml`/`nightly.yml` remain `unmanaged: true` by default, so this has no effect on an existing module until it explicitly sets `unmanaged: false` in its own `.sync.yml` (documented prominently in the README).
- The underlying array merge (`deep_merge`) is a set union, so a repeated flag like `--platform-exclude` must be combined with its value into one array element (`'--platform-exclude centos-7'`) rather than split across two — documented, and permanently regression-tested in `.ci/test_script.sh`.

## Related Issues

[CAT-2682](https://perforce.atlassian.net/browse/CAT-2682)

## Checklist

- [ ] 🟢 Spec tests. (N/A — no Ruby/Puppet source changed, only ERB templates and YAML config)
- [x] 🟢 Acceptance tests. (`.ci/test_script.sh` extended with permanent regression coverage for default, override+knockout, and adversarial-quote rendering)
- [x] Manually verified. (Verified end-to-end against real `pdk new module` / `pdk update --force` cycles)