### PR TITLE
Update puppet-strings gem version to ~> 5.0

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -583,7 +583,7 @@ Gemfile:
           - windows
     ':development, :release_prep':
       - gem: 'puppet-strings'
-        version: '~> 4.0'
+        version: '~> 5.0'
       - gem: 'puppetlabs_spec_helper'
         version: '~> 8.0'
       - gem: 'puppet-blacksmith'


### PR DESCRIPTION
## Summary
Puppet strings v4 brings in a version of `yard` with several CVEs against it.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
