### PR TITLE
(CAT-2750) Inherit secrets in ci.yml Spec job for puppetcore gem auth

### DIFF
--- a/.ci/test_script.sh
+++ b/.ci/test_script.sh
@@ -20,6 +20,7 @@ pdk update --force
 grep -A 1 "Performance/CaseWhenSplat" ./.rubocop.yml | grep -q "false" # Ensure that the update command changes the template
 grep -qF 'flags: "--platform-exclude centos-7 --platform-exclude oraclelinux-7 --message \"hello\""' .github/workflows/ci.yml # Ensure acceptance_flags override + knockout + repeated-flag-name (CR-01 regression) + adversarial quote render on ci.yml (TEST-01, TEST-02b)
 grep -qF 'flags: "--platform-exclude centos-7 --platform-exclude oraclelinux-7 --message \"hello\""' .github/workflows/nightly.yml # Ensure acceptance_flags override + knockout + repeated-flag-name (CR-01 regression) + adversarial quote render on nightly.yml independently (TEST-01, TEST-02b, D-13)
+grep -A 1 'module_ci.yml@main' .github/workflows/ci.yml | grep -qF 'secrets: "inherit"' # Ensure ci.yml Spec job inherits secrets so bundle install can authenticate against puppetcore (CAT-2750)
 pdk new class new_module
 pdk new defined_type test_type
 pdk new fact test_fact || true # not available in pdk 1.18 yet

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -23,6 +23,7 @@ jobs:
   Spec:
     if: github.event_name != 'pull_request_target'
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
+    secrets: "inherit"
 
   Acceptance:
     if: >-


### PR DESCRIPTION
## Summary

The Spec job in ci.yml.erb didn't pass secrets to the reusable module_ci.yml workflow, unlike nightly.yml and ci.yml's own Acceptance job. This left PUPPET_FORGE_TOKEN unavailable during PR CI, so bundle install couldn't authenticate against the puppetcore gem source there.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
