### PR TITLE
(CAT-2750) Update pdk-templates testing to properly bring in puppetcore gems

### DIFF
--- a/.ci/install_pdk.sh
+++ b/.ci/install_pdk.sh
@@ -8,6 +8,9 @@ RELEASE_DEB="https://apt.puppetlabs.com/puppet-tools-release-${DIST_NAME}.deb"
 NIGHTLY_DEB="https://nightlies.puppetlabs.com/apt/puppet6-nightly-release-${DIST_NAME}.deb"
 PUPPETCORE_RELEASE_DEB="https://apt-puppetcore.puppet.com/public/puppet8-release-${DIST_NAME}.deb"
 PUPPETCORE_AUTH_CONF="/etc/apt/auth.conf.d/apt-puppetcore-puppet.conf"
+# Per-commit PDK builds, reachable only once ci.yml has connected Twingate.
+NIGHTLY_INDEX_URL="https://builds.delivery.puppetlabs.net/pdk/"
+NIGHTLY_SOURCES_LIST="/etc/apt/sources.list.d/pdk-nightly.list"
 
 setup_apt() {
     local deb_url="${1}"
@@ -26,13 +29,53 @@ setup_puppetcore_apt() {
     sudo dpkg -i "$(basename "${PUPPETCORE_RELEASE_DEB}")"
 
     sudo mkdir -p "$(dirname "${PUPPETCORE_AUTH_CONF}")"
+    set +x
     printf 'machine apt-puppetcore.puppet.com\nlogin forge-key\npassword %s\n' "${PUPPET_FORGE_TOKEN}" \
         | sudo tee "${PUPPETCORE_AUTH_CONF}" > /dev/null
+    set -x
     sudo chmod 600 "${PUPPETCORE_AUTH_CONF}"
 }
 
+# Per-commit builds ahead of any official release. Requires Twingate already
+# connected (ci.yml's job, gated on PDK_CHANNEL=nightly) - builds.delivery.puppetlabs.net
+# is unreachable otherwise. Finds "latest" from the directory listing's real
+# timestamps rather than a hardcoded SHA, since a fixed SHA goes stale immediately.
+setup_nightly_apt() {
+    local latest_sha
+    latest_sha=$(curl -fsSL --max-time 30 "${NIGHTLY_INDEX_URL}" | ruby -rtime -e '
+      best = nil
+      STDIN.read.scan(%r{<a href="([0-9a-f]{40})/">[0-9a-f]{40}/</a>\s+(\d{2}-\w{3}-\d{4} \d{2}:\d{2})}).each do |sha, ts|
+        t = Time.strptime(ts, "%d-%b-%Y %H:%M")
+        best = [t, sha] if best.nil? || t > best[0]
+      end
+      puts best&.last
+    ')
+
+    if [ -z "${latest_sha}" ]; then
+        echo "ERROR: could not determine latest PDK nightly build from ${NIGHTLY_INDEX_URL}" >&2
+        exit 1
+    fi
+    echo "Using PDK nightly build ${latest_sha}"
+
+    local list_url="${NIGHTLY_INDEX_URL}${latest_sha}/repo_configs/deb/pl-pdk-${latest_sha}-${DIST_NAME}.list"
+    local repo_line
+    repo_line=$(curl -fsSL --max-time 30 "${list_url}" | grep '^deb ')
+
+    if [ -z "${repo_line}" ]; then
+        echo "ERROR: no apt repo config for '${DIST_NAME}' at ${list_url}" >&2
+        exit 1
+    fi
+
+    # Per-commit build repo is unsigned (no InRelease/Release.gpg) - mark
+    # [trusted=yes] scoped to only this one source, not apt globally.
+    echo "${repo_line}" | sed 's/^deb /deb [trusted=yes] /' \
+        | sudo tee "${NIGHTLY_SOURCES_LIST}" > /dev/null
+}
+
 main() {
-    if [ -n "${PUPPET_FORGE_TOKEN}" ]; then
+    if [ "${PDK_CHANNEL}" = "nightly" -a -n "${TWINGATE_PUBLIC_REPO_KEY}" ]; then
+        setup_nightly_apt
+    elif [ -n "${PUPPET_FORGE_TOKEN}" ]; then
         setup_puppetcore_apt
     elif [ -z "${PDK}" -o "${PDK}" = "release" ]; then
         setup_apt "${RELEASE_DEB}"

--- a/.ci/install_pdk.sh
+++ b/.ci/install_pdk.sh
@@ -73,6 +73,7 @@ setup_nightly_apt() {
 }
 
 main() {
+    set +x
     if [ "${PDK_CHANNEL}" = "nightly" -a -n "${TWINGATE_PUBLIC_REPO_KEY}" ]; then
         setup_nightly_apt
     elif [ -n "${PUPPET_FORGE_TOKEN}" ]; then
@@ -85,6 +86,7 @@ main() {
         echo "Unknown \$PDK value '${PDK}'. Supported values are 'release' and 'nightly'." >&2
         exit 1
     fi
+    set -x
 
     sudo apt-get update -qq
     sudo apt-get install -y pdk

--- a/.ci/install_pdk.sh
+++ b/.ci/install_pdk.sh
@@ -4,7 +4,10 @@ set -e # exit immediately on error
 
 DIST_NAME=$(lsb_release -cs)
 RELEASE_DEB="https://apt.puppetlabs.com/puppet-tools-release-${DIST_NAME}.deb"
+# NOTE: still points at puppet6-nightly; out of date.
 NIGHTLY_DEB="https://nightlies.puppetlabs.com/apt/puppet6-nightly-release-${DIST_NAME}.deb"
+PUPPETCORE_RELEASE_DEB="https://apt-puppetcore.puppet.com/public/puppet8-release-${DIST_NAME}.deb"
+PUPPETCORE_AUTH_CONF="/etc/apt/auth.conf.d/apt-puppetcore-puppet.conf"
 
 setup_apt() {
     local deb_url="${1}"
@@ -12,13 +15,26 @@ setup_apt() {
 
     wget "${deb_url}"
     sudo dpkg -i "${deb_file}"
-    
+
     # Add the non-expiring key from the future endpoint
     curl -fsSL https://apt.puppetlabs.com/DEB-GPG-KEY-future | sudo apt-key add -
 }
 
+setup_puppetcore_apt() {
+    # Release package installs its own signing key; no apt-key step needed.
+    wget --content-disposition "${PUPPETCORE_RELEASE_DEB}"
+    sudo dpkg -i "$(basename "${PUPPETCORE_RELEASE_DEB}")"
+
+    sudo mkdir -p "$(dirname "${PUPPETCORE_AUTH_CONF}")"
+    printf 'machine apt-puppetcore.puppet.com\nlogin forge-key\npassword %s\n' "${PUPPET_FORGE_TOKEN}" \
+        | sudo tee "${PUPPETCORE_AUTH_CONF}" > /dev/null
+    sudo chmod 600 "${PUPPETCORE_AUTH_CONF}"
+}
+
 main() {
-    if [ -z "${PDK}" -o "${PDK}" = "release" ]; then
+    if [ -n "${PUPPET_FORGE_TOKEN}" ]; then
+        setup_puppetcore_apt
+    elif [ -z "${PDK}" -o "${PDK}" = "release" ]; then
         setup_apt "${RELEASE_DEB}"
     elif [ "${PDK}" = "nightly" ]; then
         setup_apt "${NIGHTLY_DEB}"

--- a/.ci/test_script.sh
+++ b/.ci/test_script.sh
@@ -28,6 +28,8 @@ pdk new function --type v4 testfunc_v4 || true # not available in pdk 1.18 yet
 pdk new provider test_provider
 pdk new task test_task
 pdk new transport test_transport
+# ensure_bundle! skips actual `bundle install` for packaged PDK installs; pdk bundle install does not.
+pdk bundle install
 pdk validate
 pdk test unit
 popd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,21 +19,21 @@ jobs:
           export PDK_FRONTEND=noninteractive
           echo $BASH_VERSION
 
-      - name: "Install PDK"
-        run: |
-          .ci/install_pdk.sh
-
       - name: "Configure forge authentication"
         run: |
-          # Conditional shell (not a bare `env:` export): an absent secret resolves to "",
-          # and Ruby's `if ENV['PUPPET_FORGE_TOKEN']` in Gemfile.erb treats "" as truthy,
-          # which would silently break the fallback to public rubygems. See AUTH-02.
+          # Conditional shell, not a bare `env:` export: an absent secret resolves to "",
+          # and Ruby's `if ENV['PUPPET_FORGE_TOKEN']` treats "" as truthy, which would
+          # silently break the fallback to public rubygems.
           if [ -n "$FORGE_TOKEN" ]; then
             echo "PUPPET_FORGE_TOKEN=$FORGE_TOKEN" >> $GITHUB_ENV
             echo "BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM=forge-key:$FORGE_TOKEN" >> $GITHUB_ENV
           fi
         env:
           FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+
+      - name: "Install PDK"
+        run: |
+          .ci/install_pdk.sh
 
       - name: "Run Tests"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,21 @@ on:
     branches:
       - "main"
   workflow_dispatch:
+    inputs:
+      pdk_channel:
+        description: "PDK install channel"
+        type: choice
+        options:
+          - release
+          - nightly
+        default: nightly
 
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      TWINGATE_PUBLIC_REPO_KEY: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
+      PDK_CHANNEL: ${{ inputs.pdk_channel || 'nightly' }}
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
@@ -30,6 +41,20 @@ jobs:
           fi
         env:
           FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+
+      - name: "Connect Twingate (nightly PDK channel)"
+        if: env.PDK_CHANNEL == 'nightly' && env.TWINGATE_PUBLIC_REPO_KEY != ''
+        uses: "twingate/github-action@f1e69fc5af67b737d8597b759e5c607f567e77f2"  # v1
+        with:
+          service-key: ${{ env.TWINGATE_PUBLIC_REPO_KEY }}
+
+      - name: "Fix DNS for Twingate (nightly PDK channel)"
+        if: env.PDK_CHANNEL == 'nightly' && env.TWINGATE_PUBLIC_REPO_KEY != ''
+        run: |
+          sudo resolvectl dns eth0 ""
+          sudo resolvectl dns sdwan0 100.95.0.251 100.95.0.252
+          sudo resolvectl domain sdwan0 delivery.puppetlabs.net
+          sudo resolvectl flush-caches
 
       - name: "Install PDK"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,18 @@ jobs:
         run: |
           .ci/install_pdk.sh
 
+      - name: "Configure forge authentication"
+        run: |
+          # Conditional shell (not a bare `env:` export): an absent secret resolves to "",
+          # and Ruby's `if ENV['PUPPET_FORGE_TOKEN']` in Gemfile.erb treats "" as truthy,
+          # which would silently break the fallback to public rubygems. See AUTH-02.
+          if [ -n "$FORGE_TOKEN" ]; then
+            echo "PUPPET_FORGE_TOKEN=$FORGE_TOKEN" >> $GITHUB_ENV
+            echo "BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM=forge-key:$FORGE_TOKEN" >> $GITHUB_ENV
+          fi
+        env:
+          FORGE_TOKEN: ${{ secrets.PUPPET_FORGE_TOKEN || secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+
       - name: "Run Tests"
         run: |
           .ci/test_script.sh


### PR DESCRIPTION
## Summary

Wires up puppetcore authentication for pdk-templates' own dev CI (`.github/workflows/ci.yml`, `.ci/install_pdk.sh`, `.ci/test_script.sh`), so a future `config_defaults.yml` gem bump that transitively needs a puppetcore-only bolt/puppet/facter version resolves successfully instead of failing the way the puppet-strings bump did (the incident behind CAT-2750). **Confirmed fully green end-to-end** (run [31587849883](https://github.com/puppetlabs/pdk-templates/actions/runs/31587849883)).

Three parts:

1. **Forge authentication step.** `.github/workflows/ci.yml` gains a "Configure forge authentication" step, positioned before "Install PDK" and "Run Tests". It conditionally exports `PUPPET_FORGE_TOKEN` and `BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM`, reading `secrets.PUPPET_FORGE_TOKEN` with fallback to `secrets.PUPPET_FORGE_TOKEN_PUBLIC` — mirroring `puppetlabs/cat-github-actions`' `module_ci.yml` step. Guarded by `if [ -n "$FORGE_TOKEN" ]` (conditional shell, not a bare YAML `env:` block), since an absent secret would otherwise leave the vars exported-but-empty, and `Gemfile.erb`'s `ENV['PUPPET_FORGE_TOKEN']` check in Ruby treats `""` as truthy.
2. **PDK install channel.** `.ci/install_pdk.sh` installs PDK from `apt-puppetcore.puppet.com` (reusing the forge token as apt credentials) when configured, instead of the public `apt.puppetlabs.com` channel, which lags behind new PDK releases. It also gains a permanent, opt-in **nightly channel** (`pdk_channel` `workflow_dispatch` input, defaulting to `nightly` for now): connects via Twingate (`TWINGATE_PUBLIC_REPO_KEY`) and installs the latest per-commit PDK build from `builds.delivery.puppetlabs.net`, determined from the build index's real directory timestamps rather than a hardcoded SHA. Falls back to the puppetcore/release path whenever `TWINGATE_PUBLIC_REPO_KEY` isn't available (e.g. fork PRs).
3. **`pdk bundle install` before `pdk validate`.** The actual fix for a real failure found while verifying this end-to-end (see below).

## Investigation notes (why this took more than the auth step)

Getting to a genuinely green run surfaced two unrelated bugs, only one of which needed a code change here:

- **`puppetlabs/pdk` was stripping `BUNDLE_*` credentials internally** (`PDK::Util::Bundler::BundleHelper#bundle_command` routes through `Bundler.with_unbundled_env`), so `pdk new module`/`pdk update` couldn't authenticate even with the step above wired up correctly. Already fixed upstream and released in PDK 3.8.0 (tracked as CAT-2756, closed) — resolved by installing PDK from `apt-puppetcore.puppet.com` instead of the lagging public release channel.
- **`pdk validate` still failed** afterward with `Could not find gem 'facter' in locally installed gems`. Initially suspected to be a second, narrower instance of the same credential-stripping bug in `BundleHelper#binstubs!` (filed upstream as CAT-2758, merged but unreleased) — a lot of this PR's history chased that lead, including standing up the Twingate/nightly-build channel to get ahead of an unreleased fix. That channel works (confirmed live) but **turned out not to be the actual fix**: both the official release and a nightly build's shipped code were directly inspected and do contain the CAT-2758 forwarding fix, yet both still failed identically. The real cause: `PDK::Util::Bundler.ensure_bundle!` skips `bundle install!` entirely for any packaged PDK install, trusting the package's vendored gem cache (which tracks `puppet-runtime`, facter 4.19.0) rather than whatever `Gemfile.lock` actually resolves (facter 4.21.0) — no credentials or network access were ever the blocker for this specific failure. Fixed by running `pdk bundle install` (a real bundler passthrough, unaffected by that skip) before `pdk validate` in `.ci/test_script.sh`.

The nightly channel is kept as a permanent feature regardless — useful independent of this specific issue, for getting ahead of the public release channel's lag in general.

- [x] Root cause and the steps to reproduce.
- [x] Thought process behind the implementation.

## Related Issues (if any)

- [CAT-2750](https://perforce.atlassian.net/browse/CAT-2750) (this PR)

## Checklist

- [x] 🟢 Acceptance tests.
- [x] Manually verified.
