### PR TITLE
(CAT-2581) Allow puppetlabs_spec_helper 9.x versions

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -585,7 +585,9 @@ Gemfile:
       - gem: 'puppet-strings'
         version: '~> 5.0'
       - gem: 'puppetlabs_spec_helper'
-        version: '~> 8.0'
+        version:
+        - '>= 8.0'
+        - '< 10.0'
       - gem: 'puppet-blacksmith'
         version:
         - '>= 7.0'


### PR DESCRIPTION
## Summary
Allow 9.x versions to bring in Puppet 9 compatible versions of puppetlabs_syntax

## Checklist
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
