### PR TITLE
(maint) Open puppet-strings constraint to `>= 4.0`

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -583,7 +583,7 @@ Gemfile:
           - windows
     ':development, :release_prep':
       - gem: 'puppet-strings'
-        version: '~> 5.0'
+        version: '>= 4.0'
       - gem: 'puppetlabs_spec_helper'
         version:
         - '>= 8.0'

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -583,7 +583,9 @@ Gemfile:
           - windows
     ':development, :release_prep':
       - gem: 'puppet-strings'
-        version: '>= 4.0'
+        version:
+        - '>= 4.0'
+        - '< 6.0'
       - gem: 'puppetlabs_spec_helper'
         version:
         - '>= 8.0'


### PR DESCRIPTION
## Summary

Change the `puppet-strings` constraint in `config_defaults.yml`'s `:development, :release_prep` group from `'~> 5.0'` to an open floor, `'>= 4.0'`, so newly-rendered module Gemfiles can resolve `bundle install` cleanly both with and without puppetcore access.

## Why this PR exists

`bolt` is now permanently puppetcore-only past `4.0.0` (bolt-private CHANGELOG, Bolt 5.0.0: *"Migrated to PuppetCore... since bolt is only built internally now"*). Public rubygems.org's `bolt` (`4.0.0`) hard-caps `puppet-strings < 5.0`, so the current `~> 5.0` pin here makes `bundle install` unsatisfiable for anyone without puppetcore access:

```
Because bolt >= 3.27.2 depends on puppet-strings >= 2.3.0, < 5.0
  and puppet_litmus >= 2.4.0 depends on bolt >= 4.0, < 6.0,
  puppet_litmus >= 2.4.0 requires puppet-strings >= 2.3.0, < 5.0.
So, because Gemfile depends on puppet-strings ~> 5.0
  and Gemfile depends on puppet_litmus ~> 2.5,
  version solving has failed.
```

This was invisible in this repo's own CI (PR #655) because CI has `PUPPET_FORGE_TOKEN` + Twingate, routing `bolt` to the puppetcore registry, where `5.1.x` is available. Bolt 5.1.x dropped its own `puppet-strings` ceiling entirely (BOLT-87: `bolt.gemspec` now declares only `puppet-strings, '>= 2.3.0'`, no upper bound) — it doesn't pin to `~> 5.0` itself, it simply floats to whatever's newest.

An open floor (`>= 4.0`) lets whichever `bolt` is actually resolvable in a given environment narrow the final `puppet-strings` version itself, instead of hardcoding a ceiling that's only correct for one registry:

| environment | resolves to |
|---|---|
| public rubygems.org (no token) | `bolt 4.0.0` / `puppet-strings 4.1.3` |
| puppetcore (token + VPN) | `bolt 5.1.x` / `puppet-strings` 5.x |

Verified with `bundle lock` against public rubygems.org, isolating just the two conflicting gems: `~> 5.0` reproduces the failure, `>= 4.0` resolves cleanly.

## Related

- Regression introduced in #655 ("Update puppet-strings gem version to ~> 5.0")
- Same pattern as #644 (opening `puppet-blacksmith` to a wider range for the same class of reason)