### PR TITLE
fix: Raise puppet floor to 8.17 to fix silent resolution failure.

### DIFF
--- a/.ci/install_pdk.sh
+++ b/.ci/install_pdk.sh
@@ -36,6 +36,15 @@ setup_puppetcore_apt() {
     sudo chmod 600 "${PUPPETCORE_AUTH_CONF}"
 }
 
+# Mirrors main()'s puppetcore precedence: the public release PDK can't auth against rubygems-puppetcore.puppet.com even with the BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM credential set.
+setup_fallback_apt() {
+    if [ -n "${PUPPET_FORGE_TOKEN}" ]; then
+        setup_puppetcore_apt
+    else
+        setup_apt "${RELEASE_DEB}"
+    fi
+}
+
 # Per-commit builds ahead of any official release. Requires Twingate already
 # connected (ci.yml's job, gated on PDK_CHANNEL=nightly) - builds.delivery.puppetlabs.net
 # is unreachable otherwise. Finds "latest" from the directory listing's real
@@ -52,17 +61,26 @@ setup_nightly_apt() {
     ')
 
     if [ -z "${latest_sha}" ]; then
-        echo "ERROR: could not determine latest PDK nightly build from ${NIGHTLY_INDEX_URL}" >&2
-        exit 1
+        echo "WARNING: could not determine latest PDK nightly build from ${NIGHTLY_INDEX_URL}; falling back to PDK release channel" >&2
+        setup_fallback_apt
+        return
     fi
     echo "Using PDK nightly build ${latest_sha}"
 
     local list_url="${NIGHTLY_INDEX_URL}${latest_sha}/repo_configs/deb/pl-pdk-${latest_sha}-${DIST_NAME}.list"
+
+    # A per-commit build can be indexed before this dist's config finishes uploading; fall back rather than fail CI outright.
+    if ! curl -fsSL --max-time 30 --output /dev/null "${list_url}"; then
+        echo "WARNING: no PDK nightly build for '${DIST_NAME}' at ${list_url}; falling back to PDK release channel" >&2
+        setup_fallback_apt
+        return
+    fi
+
     local repo_line
     repo_line=$(curl -fsSL --max-time 30 "${list_url}" | grep '^deb ')
 
     if [ -z "${repo_line}" ]; then
-        echo "ERROR: no apt repo config for '${DIST_NAME}' at ${list_url}" >&2
+        echo "ERROR: apt repo config at ${list_url} has no 'deb ' line" >&2
         exit 1
     fi
 

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -259,8 +259,13 @@ Gemfile:
         condition: "Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
       - gem: deep_merge
         version: '~> 1.2.2'
+      # See docs/adr/0001 for why this is a resolved-source check.
       - gem: 'voxpupuli-puppet-lint-plugins'
         version: '~> 7.0'
+        condition: 'gemsource_puppetcore != "https://rubygems.org"'
+      - gem: 'voxpupuli-puppet-lint-plugins'
+        version: '~> 6.0'
+        condition: 'gemsource_puppetcore == "https://rubygems.org"'
       - gem: 'facterdb'
         version: '~> 2.1'
         condition: "Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))"
@@ -314,10 +319,13 @@ Gemfile:
         version:
         - '>= 4.0'
         - '< 6.0'
+      # See docs/adr/0001 for why this is a resolved-source check.
       - gem: 'puppetlabs_spec_helper'
-        version:
-        - '>= 8.0'
-        - '< 10.0'
+        version: '~> 9.0'
+        condition: 'gemsource_puppetcore != "https://rubygems.org"'
+      - gem: 'puppetlabs_spec_helper'
+        version: '~> 8.0'
+        condition: 'gemsource_puppetcore == "https://rubygems.org"'
       - gem: 'puppet-blacksmith'
         version:
         - '>= 7.0'

--- a/docs/adr/0001-route-gemfile-puppetcore-gem-selection-by-resolved-gemsource-not-by-env-var-provenance.md
+++ b/docs/adr/0001-route-gemfile-puppetcore-gem-selection-by-resolved-gemsource-not-by-env-var-provenance.md
@@ -1,0 +1,34 @@
+# 0001. Route Gemfile puppetcore gem selection by resolved gemsource, not by env-var provenance
+
+Date: 2026-09-07
+
+## Status
+
+Accepted
+
+## Context
+
+Recently, modules using a puppetcore gemsource ruby 3 began automatically resolving `puppet` to an older version `<= 8.16` instead of the expected `8.21`.  The cause of this was that puppet 8.17 capped its own `multi_json` dependency at `<= 1.19.0`. Left unconstrained, Bundler resolves `multi_json`'s latest (`1.21.0`) first and silently backtracks `puppet` to whatever old release has no `multi_json` dependency at all — an old `8.x` release, not the intended newer one.  Fortunately on puppetcore and ruby 4, `puppet` resolves correctly to `~> 9.0`.
+
+Although the solution for `puppet` is simple—raise `puppet`'s floor from `8.11` to `8.17`—the module Gemfile must continue to work with multiple puppetcore gem sources, <https://rubygems.org>, and different Ruby versions.
+
+Therefore 2 questions must be answered at bundler Gemfile resolution:
+
+- **is the gemsource that will actually serve this `bundle install` a puppetcore-capable one, or the plain public `rubygems.org`?**
+- **which Ruby version are we on, 3 or 4?**
+
+Several puppetcore gating strategies were investigated at first but ruled out, e.g., switching on `ENV['PUPPET_FORGE_TOKEN']` or even on the module's own `metadata.json` content.  A simple strategy was selected:  When `gemsource_puppetcore` is **NOT** equal to <https://rubygems.org>, then bundler will assume puppetcore gemsource.
+
+## Decision
+
+Therefore, `gemsource_puppetcore != 'https://rubygems.org'` was added to the Gemfile to select puppetcore or public; and additional ruby version checking enables the correct selection of `puppet`:
+
+- `8.10` for <https://rubygems.org>
+- `~> 8.17` for ruby 3 and puppetcore
+- `~> 9.0` for ruby 4 and puppetcore
+
+**NOTE**: This design assumes that `gemsource_puppetcore` other than `https://rubygems.org` is puppetcore.  This was chosen for several reasons: one.  Since we have multiple puppetcore sources (<https://rubygems-puppetcore.puppet.com>, <https://artifactory.delivery.puppet.net/.../rubygems>, etc), then anything other than public gemsource `https://rubygems.org` is assumed to be puppetcore.  If, however, the gemsource is different from the public gemsource and not one of our valid puppetcore sources, then the bundler Gemfile resolution will simply fail loudly.  This is by design.
+
+## Consequences
+
+The above design solves not only the selection of `puppet` but also the selection of 2 associated dev/test gems `voxpupuli-puppet-lint-plugins`, `puppetlabs_spec_helper`.  These 2 gems must move together for puppetcore gemsources.

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -23,6 +23,7 @@ jobs:
   Spec:
     if: github.event_name != 'pull_request_target'
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
+    secrets: "inherit"
 
   Acceptance:
     if: >-

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -85,6 +85,17 @@ def location_for(place_or_constraint, fake_constraint = nil, opts = {})
   end
 end
 
+# Works around a bundler multi_json/puppet resolution bug - see docs/adr/0001.
+def puppet_floor_version(puppetcore_source)
+  return nil if puppetcore_source == 'https://rubygems.org'
+
+  ruby_version = Gem::Version.new(RUBY_VERSION.dup)
+  return '~> 9.0' if Gem::Requirement.create('>= 4.0.0').satisfied_by?(ruby_version)
+  return '~> 8.17' if Gem::Requirement.create('>= 3.1.0').satisfied_by?(ruby_version)
+
+  nil # puppet 8+ requires ruby >= 3.1; leave older rubies unconstrained
+end
+
 # Print debug information if DEBUG_GEMS or VERBOSE is set
 def print_gem_statement_for(gems)
   puts 'DEBUG: Gem definitions that will be generated:'
@@ -128,7 +139,7 @@ end
 
 gems = {}
 bolt_version = ENV.fetch('BOLT_GEM_VERSION', nil)
-puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
+puppet_version = ENV.fetch('PUPPET_GEM_VERSION', puppet_floor_version(gemsource_puppetcore))
 facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
 hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 


### PR DESCRIPTION
## Problem:

- puppet `8.17` introduced an upper constraint of `1.19.0` on `multi_json`.  Since bundler seems to resolve `multi_json` first and to it's latest of `1.21.0`, then bundler silently downgrades puppet to `<= 8.16`.

## Solution

- Add a function `puppet_floor_version` that resolves puppetcore puppet to `~> 8.17` for ruby 3 and `~> 9.0` for ruby 4.

## Additional Changes

- Select `voxpupuli-puppet-lint-plugins` and `puppetlabs_spec_helper` versions based on whether `gemsource_puppetcore` points at the public rubygems.org source or an internal Puppetcore source, avoiding resolver conflicts on each axis.
- Added `secrets: inherit` to the `Spec` job in `ci.yml.erb` so the puppetcore test run has the secrets it needs.
- `.ci/install_pdk.sh`: fall back to the puppetcore-built PDK channel (not the plain public release PDK) when the latest nightly build's per-dist repo config isn't available yet, since the public release PDK can't authenticate against `rubygems-puppetcore.puppet.com`.